### PR TITLE
feat(crons): scraper cron system with Luma + ETHGlobal sources

### DIFF
--- a/crons/.env.example
+++ b/crons/.env.example
@@ -1,0 +1,36 @@
+# --- Which sources to run ---------------------------------------------------
+# Comma-separated source names (see src/sources/index.ts). Empty = run all.
+# Available: luma, ethglobal
+SOURCES=luma,ethglobal
+
+# --- Luma source ------------------------------------------------------------
+# Location to scan. Either a free-text location (geocoded via Nominatim)...
+LOCATION="Paris, France"
+# ...or explicit coordinates (take precedence over LOCATION).
+# LAT=48.8566
+# LNG=2.3522
+
+# --- ETHGlobal source -------------------------------------------------------
+# Which event statuses to keep (comma-separated). Default: future.
+# Options: future, finished, cancelled
+ETHGLOBAL_STATUSES=future
+
+# --- Fetch tuning -----------------------------------------------------------
+LIMIT=20                 # max events per source
+DELAY=2.0                # base seconds between paginated requests
+QUERY=                   # optional free-text filter
+AFTER=                   # only events starting on/after (YYYY-MM-DD)
+BEFORE=                  # only events starting on/before (YYYY-MM-DD)
+INCLUDE_DESCRIPTIONS=true
+
+# --- Directory API ----------------------------------------------------------
+PUSH_API_URL=https://hackathons-production-960c.up.railway.app/api/hackathons
+# EXISTS_API_URL is derived from PUSH_API_URL by default.
+# EXISTS_API_URL=https://hackathons-production-960c.up.railway.app/api/hackathons/exists
+HACKATHONS_API_SECRET=   # sent as x-api-secret header
+ORGANIZER_ID=00000000-0000-0000-0000-000000000000
+
+# --- Ops --------------------------------------------------------------------
+DRY_RUN=false            # print payloads instead of pushing
+# OUTPUT_FILE=out.json   # also dump the events that would be pushed
+DISCORD_WEBHOOK_URL=     # optional run summary notification

--- a/crons/.gitignore
+++ b/crons/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+.env.local
+out.json
+*.log

--- a/crons/README.md
+++ b/crons/README.md
@@ -1,0 +1,92 @@
+# crons
+
+Scheduled scrapers that discover hackathons from external sources and push them
+into the Hackathon Atlas directory.
+
+Runs on [Bun](https://bun.sh). Deployed as a Railway cron job (deployed via the
+Railway CLI).
+
+## Layout
+
+```
+crons/
+├── src/
+│   ├── index.ts          # runner: fetch → dedup → push → notify
+│   ├── config.ts         # env-driven config
+│   ├── types.ts          # NormalizedEvent + Source interface
+│   ├── lib/
+│   │   ├── http.ts       # fetch helpers (User-Agent, sleep, jitter)
+│   │   ├── geocode.ts    # Nominatim geocoding
+│   │   ├── push.ts       # /exists dedup + POST to the directory
+│   │   └── notify.ts     # Discord summary
+│   └── sources/
+│       ├── index.ts      # source registry (the extension point)
+│       ├── luma.ts       # Luma (lu.ma) source
+│       └── ethglobal.ts  # ETHGlobal (ethglobal.com) source
+├── .env.example
+└── package.json
+```
+
+## Run locally
+
+```sh
+cp .env.example .env      # fill in the values
+bun install
+bun run start             # fetch + push
+bun run dry-run           # print payloads, push nothing
+```
+
+## Pipeline
+
+1. **Fetch** — each selected source returns `NormalizedEvent[]`.
+2. **Dedup** — events already in the directory (matched by `link` via
+   `/api/hackathons/exists`) are dropped.
+3. **Push** — remaining events are `POST`ed to `/api/hackathons`
+   (authenticated with `x-api-secret`).
+4. **Notify** — a summary is sent to Discord (if a webhook is configured).
+
+Everything is configured via environment variables — see
+[`.env.example`](./.env.example).
+
+## Sources
+
+| Source      | Discovery                                                       | Notes |
+| ----------- | -------------------------------------------------------------- | ----- |
+| `luma`      | Luma discovery API, scanned by geolocation (`LOCATION`/`LAT`/`LNG`). | Fetches descriptions from the per-event API. |
+| `ethglobal` | ETHGlobal `/events` RSC payload — one request lists every event. | Keeps `type=hackathon`; filter statuses with `ETHGLOBAL_STATUSES` (default `future`). Cover/description come from each event page's `og:*` tags. Prize pool isn't reliably exposed, so `cashPrize` is `-1`. |
+
+## Adding a new source
+
+A source is anything that implements the `Source` interface from
+[`src/types.ts`](./src/types.ts): a `name` and a `fetchEvents(ctx)` that returns
+normalized events. The runner handles dedup, pushing, and notifications — a
+source only has to fetch and normalize.
+
+1. Create `src/sources/<name>.ts`:
+
+   ```ts
+   import type { Source } from "../types.js";
+
+   export async function createDevpostSource(): Promise<Source> {
+     return {
+       name: "devpost",
+       async fetchEvents(ctx) {
+         // fetch, then map each item to a NormalizedEvent
+         return [];
+       },
+     };
+   }
+   ```
+
+2. Register it in [`src/sources/index.ts`](./src/sources/index.ts):
+
+   ```ts
+   export const SOURCE_REGISTRY = {
+     luma: createLumaSource,
+     devpost: createDevpostSource, // 👈
+   };
+   ```
+
+3. Select it at runtime with `SOURCES=devpost` (or leave `SOURCES` empty to run
+   every registered source).
+```

--- a/crons/bun.lock
+++ b/crons/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "crons",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "5.9.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/crons/package.json
+++ b/crons/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "crons",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun src/index.ts",
+    "dry-run": "DRY_RUN=true bun src/index.ts",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "5.9.2"
+  }
+}

--- a/crons/src/config.ts
+++ b/crons/src/config.ts
@@ -1,0 +1,86 @@
+// Central config, resolved once from the environment.
+
+const DEFAULT_PUSH_API_URL =
+  "https://hackathons-production-960c.up.railway.app/api/hackathons";
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function envBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+}
+
+function parseDate(input: string): Date {
+  const trimmed = input.trim();
+  if (trimmed.length === 10) return new Date(`${trimmed}T00:00:00.000Z`);
+  return new Date(trimmed);
+}
+
+/** Derive the `/exists` dedup endpoint from the push endpoint. */
+function deriveExistsApiUrl(pushApiUrl: string): string {
+  try {
+    const url = new URL(pushApiUrl);
+    if (url.pathname.endsWith("/api/hackathons")) {
+      url.pathname = `${url.pathname}/exists`;
+      return url.toString();
+    }
+  } catch {
+    // Fall through to the default below.
+  }
+  const url = new URL(DEFAULT_PUSH_API_URL);
+  url.pathname = `${url.pathname}/exists`;
+  return url.toString();
+}
+
+export type Config = {
+  limit: number;
+  delay: number;
+  includeDescriptions: boolean;
+  dryRun: boolean;
+  after?: Date;
+  before?: Date;
+  query?: string;
+  /** Comma-separated source names to run; empty = run all registered. */
+  sources: string[];
+  pushApiUrl: string;
+  existsApiUrl: string;
+  apiSecret?: string;
+  organizerId: string;
+  discordWebhookUrl?: string;
+  outputFile?: string;
+};
+
+export function loadConfig(): Config {
+  const pushApiUrl = process.env.PUSH_API_URL ?? DEFAULT_PUSH_API_URL;
+  const existsApiUrl =
+    process.env.EXISTS_API_URL ?? deriveExistsApiUrl(pushApiUrl);
+
+  const sources = (process.env.SOURCES ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+  return {
+    limit: Math.max(1, envNumber("LIMIT", 20)),
+    delay: envNumber("DELAY", 2.0),
+    includeDescriptions: envBool("INCLUDE_DESCRIPTIONS", true),
+    dryRun: envBool("DRY_RUN", false),
+    after: process.env.AFTER ? parseDate(process.env.AFTER) : undefined,
+    before: process.env.BEFORE ? parseDate(process.env.BEFORE) : undefined,
+    query: process.env.QUERY || undefined,
+    sources,
+    pushApiUrl,
+    existsApiUrl,
+    apiSecret: process.env.HACKATHONS_API_SECRET,
+    organizerId:
+      process.env.ORGANIZER_ID ?? "00000000-0000-0000-0000-000000000000",
+    discordWebhookUrl: process.env.DISCORD_WEBHOOK_URL,
+    outputFile: process.env.OUTPUT_FILE,
+  };
+}

--- a/crons/src/index.ts
+++ b/crons/src/index.ts
@@ -1,0 +1,115 @@
+// Cron runner.
+//
+// For each selected source: fetch -> dedup against the directory -> push.
+// Sends a Discord summary at the end. Configure entirely via env vars
+// (see .env.example). Run with: `bun run start` (from the crons/ dir).
+
+import { loadConfig } from "./config.js";
+import { randomBetween, sleep } from "./lib/http.js";
+import { notifyDiscordSummary, type RunSummary } from "./lib/notify.js";
+import { eventExists, pushEvent } from "./lib/push.js";
+import { loadSources } from "./sources/index.js";
+import type { NormalizedEvent, SourceContext } from "./types.js";
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const sources = await loadSources(config.sources);
+
+  if (!sources.length) {
+    throw new Error("No sources to run. Check the SOURCES env var / registry.");
+  }
+
+  console.error(`[*] Running sources: ${sources.map((s) => s.name).join(", ")}`);
+
+  // 1. Fetch from every source.
+  const bySource: Record<string, number> = {};
+  const fetched: NormalizedEvent[] = [];
+
+  for (const source of sources) {
+    const ctx: SourceContext = {
+      limit: config.limit,
+      delay: config.delay,
+      after: config.after,
+      before: config.before,
+      query: config.query,
+      includeDescriptions: config.includeDescriptions,
+      log: (msg) => console.error(`[${source.name}] ${msg}`),
+    };
+
+    try {
+      const events = await source.fetchEvents(ctx);
+      bySource[source.name] = events.length;
+      fetched.push(...events);
+      console.error(`[*] ${source.name}: fetched ${events.length}`);
+    } catch (error) {
+      bySource[source.name] = 0;
+      console.error(`[!] ${source.name} failed: ${String(error)}`);
+    }
+  }
+
+  // 2. Dedup: drop events already present in the directory.
+  const toPush: NormalizedEvent[] = [];
+  let filteredExisting = 0;
+
+  for (const event of fetched) {
+    if (event.link && (await eventExists(event.link, config))) {
+      filteredExisting += 1;
+      console.error(`[*] Skipping existing: ${event.title.slice(0, 50)}`);
+      continue;
+    }
+    toPush.push(event);
+  }
+
+  if (config.outputFile) {
+    await Bun.write(config.outputFile, JSON.stringify(toPush, null, 2));
+    console.error(`[*] Exported ${toPush.length} events to ${config.outputFile}`);
+  }
+
+  // 3. Push (unless dry run).
+  let success = 0;
+  let failed = 0;
+
+  for (let i = 0; i < toPush.length; i++) {
+    const event = toPush[i]!;
+
+    if (config.dryRun) {
+      console.log(JSON.stringify({ ...event, organizerId: config.organizerId }));
+      continue;
+    }
+
+    console.error(`[*] ${i + 1}/${toPush.length} pushing: ${event.title.slice(0, 50)}`);
+    const result = await pushEvent(event, config);
+
+    if (result.status >= 200 && result.status < 300) {
+      success += 1;
+      console.error(`  [OK] ${result.status}`);
+    } else {
+      failed += 1;
+      console.error(`  [FAIL] ${result.status} ${result.body}`);
+    }
+
+    if (i < toPush.length - 1) await sleep(randomBetween(300, 800));
+  }
+
+  // 4. Summary + Discord.
+  const summary: RunSummary = {
+    totalFetched: fetched.length,
+    filteredExisting,
+    totalToPush: toPush.length,
+    success,
+    failed,
+    dryRun: config.dryRun,
+    bySource,
+  };
+
+  const notified = await notifyDiscordSummary(summary, config.discordWebhookUrl);
+
+  if (!config.dryRun) {
+    console.error(`[*] Done: ${success} OK, ${failed} failed`);
+  }
+  if (config.discordWebhookUrl) {
+    console.error(notified ? "[*] Discord summary sent." : "[*] Discord summary failed.");
+  }
+}
+
+await main();

--- a/crons/src/lib/geocode.ts
+++ b/crons/src/lib/geocode.ts
@@ -1,0 +1,19 @@
+// Geocoding via Nominatim (OpenStreetMap). Shared by sources that only expose
+// a free-text location and need coordinates.
+
+import { fetchJson, USER_AGENT } from "./http.js";
+
+const NOMINATIM_API = "https://nominatim.openstreetmap.org/search";
+
+export type Coordinates = { lat: number; lng: number };
+
+/** Resolve a free-text location to coordinates, or null if not found. */
+export async function geocode(location: string): Promise<Coordinates | null> {
+  const params = new URLSearchParams({ format: "json", q: location, limit: "1" });
+  const data = await fetchJson<Array<{ lat: string; lon: string }>>(
+    `${NOMINATIM_API}?${params.toString()}`,
+    { headers: { "User-Agent": USER_AGENT } },
+  );
+  if (!data || !data.length) return null;
+  return { lat: Number(data[0]!.lat), lng: Number(data[0]!.lon) };
+}

--- a/crons/src/lib/http.ts
+++ b/crons/src/lib/http.ts
@@ -1,0 +1,25 @@
+// Small HTTP helpers shared across sources.
+
+export const USER_AGENT = "HackathonAtlasScraper/1.0";
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export const randomBetween = (min: number, max: number): number =>
+  Math.random() * (max - min) + min;
+
+/** Fetch JSON with the shared User-Agent. Returns null on a non-OK response. */
+export async function fetchJson<T>(
+  url: string,
+  init?: RequestInit,
+): Promise<T | null> {
+  const resp = await fetch(url, {
+    ...init,
+    headers: {
+      "User-Agent": USER_AGENT,
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!resp.ok) return null;
+  return (await resp.json()) as T;
+}

--- a/crons/src/lib/notify.ts
+++ b/crons/src/lib/notify.ts
@@ -1,0 +1,49 @@
+// Discord webhook notifications for run summaries.
+
+export type RunSummary = {
+  totalFetched: number;
+  filteredExisting: number;
+  totalToPush: number;
+  success: number;
+  failed: number;
+  dryRun: boolean;
+  /** Per-source counts, for visibility as sources are added. */
+  bySource: Record<string, number>;
+};
+
+/** Post a run summary to Discord. Returns false if no webhook / on error. */
+export async function notifyDiscordSummary(
+  summary: RunSummary,
+  webhookUrl: string | undefined,
+): Promise<boolean> {
+  if (!webhookUrl) return false;
+
+  const status = summary.failed > 0 ? "PARTIAL" : "OK";
+  const bySource = Object.entries(summary.bySource)
+    .map(([name, count]) => `  - ${name}: ${count}`)
+    .join("\n");
+
+  const content = [
+    `Cron scrapers -> Hackathons: ${status}`,
+    `- fetched: ${summary.totalFetched}`,
+    `- filtered_existing: ${summary.filteredExisting}`,
+    `- to_push: ${summary.totalToPush}`,
+    `- added_ok: ${summary.success}`,
+    `- failed: ${summary.failed}`,
+    `- dry_run: ${summary.dryRun ? "yes" : "no"}`,
+    bySource ? `- fetched_by_source:\n${bySource}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  try {
+    const resp = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}

--- a/crons/src/lib/push.ts
+++ b/crons/src/lib/push.ts
@@ -1,0 +1,47 @@
+// Talks to the hackathons API: dedup (`/exists`) and insert (`POST`).
+
+import type { Config } from "../config.js";
+import type { NormalizedEvent } from "../types.js";
+
+/** Returns true if an event with this link already exists in the directory. */
+export async function eventExists(
+  link: string,
+  config: Config,
+): Promise<boolean> {
+  const url = `${config.existsApiUrl}?link=${encodeURIComponent(link)}`;
+  try {
+    const resp = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!resp.ok) return false;
+    const data = (await resp.json()) as { exists?: boolean };
+    return Boolean(data?.exists);
+  } catch {
+    return false;
+  }
+}
+
+export type PushResult = { status: number; body: string };
+
+/** POST a normalized event to the directory. Never throws. */
+export async function pushEvent(
+  event: NormalizedEvent,
+  config: Config,
+): Promise<PushResult> {
+  const payload = {
+    ...event,
+    organizerId: config.organizerId,
+  };
+
+  try {
+    const resp = await fetch(config.pushApiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(config.apiSecret ? { "x-api-secret": config.apiSecret } : {}),
+      },
+      body: JSON.stringify(payload),
+    });
+    return { status: resp.status, body: await resp.text() };
+  } catch (error) {
+    return { status: 0, body: String(error) };
+  }
+}

--- a/crons/src/sources/ethglobal.ts
+++ b/crons/src/sources/ethglobal.ts
@@ -1,0 +1,195 @@
+// ETHGlobal (ethglobal.com) source.
+//
+// ETHGlobal is a Next.js App Router site. The full events list is embedded in
+// the RSC "flight" payload of the /events page as a single `events` array — so
+// one request yields every event (name, slug, type, medium, dates, city). We
+// keep the hackathons, then fetch each event page once for a stable cover image
+// and description (the list payload only carries expiring presigned URLs).
+
+import { geocode } from "../lib/geocode.js";
+import { randomBetween, sleep, USER_AGENT } from "../lib/http.js";
+import type { NormalizedEvent, Source, SourceContext } from "../types.js";
+
+const EVENTS_URL = "https://ethglobal.com/events";
+const EVENT_BASE = "https://ethglobal.com/events";
+
+/** Statuses to keep. Override with ETHGLOBAL_STATUSES (comma-separated). */
+const DEFAULT_STATUSES = ["future"];
+
+/** Shape of an event entry inside the ETHGlobal RSC payload (subset we use). */
+type EthEvent = {
+  name: string;
+  slug: string;
+  type: string; // "hackathon" | "summit" | "meetup" | ...
+  medium: string; // "physical" | "virtual"
+  status: string; // "future" | "finished" | "cancelled"
+  startTime: string;
+  endTime: string;
+  tagline: string | null;
+  banner?: { fullUrl?: string } | null;
+  city?: { name?: string; country?: { name?: string } | null } | null;
+};
+
+/**
+ * Pull the `events` array out of the ETHGlobal RSC flight payload.
+ *
+ * The payload is embedded inside a `self.__next_f.push([n,"<huge string>"])`
+ * call, so every quote in the JSON appears escaped as `\"` in the HTML. We
+ * locate `\"events\":[`, bracket-match the array in the *escaped* text (a `\"`
+ * pair toggles string context), then reverse one level of escaping with
+ * JSON.parse before parsing the array itself.
+ */
+function extractEvents(html: string): EthEvent[] {
+  const key = '\\"events\\":['; // literal backslash-quote as it appears in HTML
+  const start = html.indexOf(key);
+  if (start < 0) return [];
+
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  let end = -1;
+  for (let i = start + key.length - 1; i < html.length; i++) {
+    const c = html[i];
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (c === "\\") {
+      if (html[i + 1] === '"') {
+        inStr = !inStr; // \" toggles JSON string context
+        i++;
+        continue;
+      }
+      esc = true; // some other escape (\\, \n, \uXXXX): skip next char
+      continue;
+    }
+    if (inStr) continue;
+    if (c === "[") depth++;
+    else if (c === "]") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end < 0) return [];
+
+  try {
+    const escaped = html.slice(start + key.length - 1, end + 1);
+    const json = JSON.parse(`"${escaped}"`) as string; // reverse one escape level
+    return JSON.parse(json) as EthEvent[];
+  } catch {
+    return [];
+  }
+}
+
+/** Fetch an event page and pull the stable og:image / og:description. */
+async function fetchMeta(
+  slug: string,
+): Promise<{ coverUrl: string; description: string }> {
+  try {
+    // ETHGlobal event pages currently return HTTP 500 for logged-out clients,
+    // but the <head> (og:* meta) still renders — so we parse the body
+    // regardless of status instead of bailing on a non-2xx response.
+    const resp = await fetch(`${EVENT_BASE}/${slug}`, {
+      headers: { "User-Agent": USER_AGENT },
+    });
+    const html = await resp.text();
+    const og = (prop: string) =>
+      html.match(
+        new RegExp(`<meta property="og:${prop}" content="([^"]*)"`, "i"),
+      )?.[1] ?? "";
+    return { coverUrl: og("image"), description: og("description") };
+  } catch {
+    return { coverUrl: "", description: "" };
+  }
+}
+
+function resolveStatuses(): string[] {
+  const raw = process.env.ETHGLOBAL_STATUSES;
+  if (!raw) return DEFAULT_STATUSES;
+  return raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export async function createEthGlobalSource(): Promise<Source> {
+  const statuses = new Set(resolveStatuses());
+
+  return {
+    name: "ethglobal",
+    async fetchEvents(ctx: SourceContext): Promise<NormalizedEvent[]> {
+      ctx.log(`fetching ${EVENTS_URL}`);
+      const resp = await fetch(EVENTS_URL, {
+        headers: { "User-Agent": USER_AGENT },
+      });
+      if (!resp.ok) throw new Error(`[ethglobal] events page ${resp.status}`);
+
+      const all = extractEvents(await resp.text());
+      ctx.log(`parsed ${all.length} events from RSC payload`);
+
+      const query = ctx.query?.toLowerCase();
+      const hackathons = all.filter((e) => {
+        if (e.type !== "hackathon") return false;
+        if (!statuses.has(e.status)) return false;
+        const start = new Date(e.startTime);
+        if (ctx.after && start < ctx.after) return false;
+        if (ctx.before && start > ctx.before) return false;
+        if (query && !e.name.toLowerCase().includes(query)) return false;
+        return true;
+      });
+
+      ctx.log(`kept ${hackathons.length} hackathons (statuses: ${[...statuses].join(", ")})`);
+      const selected = hackathons.slice(0, ctx.limit);
+      const events: NormalizedEvent[] = [];
+
+      for (let i = 0; i < selected.length; i++) {
+        const e = selected[i]!;
+        const online = e.medium !== "physical" || !e.city?.name;
+        const cityName = e.city?.name ?? "";
+        const countryName = e.city?.country?.name ?? "";
+
+        let latitude: number | null = null;
+        let longitude: number | null = null;
+        if (!online && cityName) {
+          const q = countryName ? `${cityName}, ${countryName}` : cityName;
+          const coords = await geocode(q);
+          if (coords) {
+            latitude = coords.lat;
+            longitude = coords.lng;
+          }
+          await sleep(randomBetween(1000, 1500)); // be gentle with Nominatim
+        }
+
+        let coverUrl = e.banner?.fullUrl ?? "";
+        let description = e.tagline ?? "";
+        if (ctx.includeDescriptions) {
+          ctx.log(`enriching ${i + 1}/${selected.length}: ${e.name.slice(0, 50)}`);
+          const meta = await fetchMeta(e.slug);
+          if (meta.coverUrl) coverUrl = meta.coverUrl;
+          if (meta.description) description = meta.description;
+          if (i < selected.length - 1) await sleep(randomBetween(800, 1500));
+        }
+
+        events.push({
+          title: e.name,
+          description,
+          city: online ? "Online" : cityName,
+          latitude,
+          longitude,
+          startTime: e.startTime,
+          endTime: e.endTime,
+          link: `${EVENT_BASE}/${e.slug}`,
+          cashPrize: -1, // total prize pool isn't reliably in the payload
+          tags: ["ethglobal", "web3", online ? "online" : "in-person"],
+          participantsCount: 0,
+          coverUrl,
+        });
+      }
+
+      return events;
+    },
+  };
+}

--- a/crons/src/sources/index.ts
+++ b/crons/src/sources/index.ts
@@ -1,0 +1,38 @@
+// Source registry.
+//
+// To add a new data source (Devpost, MLH, ...):
+//   1. Create `src/sources/<name>.ts` exporting a factory that returns a Source.
+//   2. Register it below, keyed by its name.
+// The runner will pick it up automatically. Select which sources run at a
+// given time with the SOURCES env var (comma-separated); empty = all of them.
+
+import type { Source } from "../types.js";
+import { createEthGlobalSource } from "./ethglobal.js";
+import { createLumaSource } from "./luma.js";
+
+/** A factory builds a source, possibly doing async setup (e.g. geocoding). */
+export type SourceFactory = () => Promise<Source>;
+
+export const SOURCE_REGISTRY: Record<string, SourceFactory> = {
+  luma: createLumaSource,
+  ethglobal: createEthGlobalSource,
+  // devpost: createDevpostSource,
+  // mlh: createMlhSource,
+};
+
+/** Instantiate the sources selected by config (empty selection = all). */
+export async function loadSources(selected: string[]): Promise<Source[]> {
+  const names = selected.length ? selected : Object.keys(SOURCE_REGISTRY);
+  const sources: Source[] = [];
+
+  for (const name of names) {
+    const factory = SOURCE_REGISTRY[name];
+    if (!factory) {
+      console.error(`[!] Unknown source '${name}', skipping.`);
+      continue;
+    }
+    sources.push(await factory());
+  }
+
+  return sources;
+}

--- a/crons/src/sources/luma.ts
+++ b/crons/src/sources/luma.ts
@@ -1,0 +1,194 @@
+// Luma (lu.ma) source.
+//
+// Uses Luma's public discovery API, filtered by geolocation. Each candidate
+// event is normalized into `NormalizedEvent`. Descriptions are fetched lazily
+// from the per-event `api.lu.ma/url` endpoint (ProseMirror "mirror" format).
+
+import { geocode } from "../lib/geocode.js";
+import { fetchJson, randomBetween, sleep, USER_AGENT } from "../lib/http.js";
+import type { NormalizedEvent, Source, SourceContext } from "../types.js";
+
+const LUMA_API = "https://api.lu.ma/discover/get-paginated-events";
+const MAX_PAGES = 20;
+
+type LumaResponse = {
+  entries?: Array<Record<string, any>>;
+  has_more?: boolean;
+  next_cursor?: string;
+};
+
+/** A geographic region to scan. Add entries to widen coverage. */
+type Region = { label: string; lat: number; lng: number };
+
+function eventStartDate(entry: Record<string, any>): Date | null {
+  const start = entry?.event?.start_at;
+  if (!start) return null;
+  const d = new Date(start);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+async function fetchEventsPage(args: {
+  lat: number;
+  lng: number;
+  query?: string;
+  cursor?: string;
+}): Promise<LumaResponse> {
+  const params = new URLSearchParams({
+    geo_latitude: String(args.lat),
+    geo_longitude: String(args.lng),
+    pagination_limit: "50",
+  });
+  if (args.cursor) params.set("pagination_cursor", args.cursor);
+  if (args.query) params.set("query", args.query);
+
+  const data = await fetchJson<LumaResponse>(
+    `${LUMA_API}?${params.toString()}`,
+    { headers: { "User-Agent": USER_AGENT } },
+  );
+  return data ?? {};
+}
+
+async function scrapeRegion(
+  region: Region,
+  ctx: SourceContext,
+): Promise<Array<Record<string, any>>> {
+  const collected: Array<Record<string, any>> = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_PAGES && collected.length < ctx.limit; page++) {
+    const data = await fetchEventsPage({
+      lat: region.lat,
+      lng: region.lng,
+      query: ctx.query,
+      cursor,
+    });
+
+    const entries = data.entries ?? [];
+    if (!entries.length) break;
+
+    for (const entry of entries) {
+      const dt = eventStartDate(entry);
+      if (ctx.after && dt && dt < ctx.after) continue;
+      if (ctx.before && dt && dt > ctx.before) continue;
+      collected.push(entry);
+      if (collected.length >= ctx.limit) break;
+    }
+
+    if (collected.length >= ctx.limit || !data.has_more) break;
+
+    cursor = data.next_cursor || entries[entries.length - 1]?.api_id;
+    if (!cursor) break;
+
+    const jitter = ctx.delay + randomBetween(0.5, 1.5);
+    ctx.log(`[${region.label}] waiting ${jitter.toFixed(1)}s before next page`);
+    await sleep(jitter * 1000);
+  }
+
+  return collected.slice(0, ctx.limit);
+}
+
+function extractTextFromMirror(node: any): string {
+  if (Array.isArray(node)) {
+    return node.map((n) => extractTextFromMirror(n)).join("");
+  }
+  if (node && typeof node === "object") {
+    if (node.type === "hard_break") return "\n";
+    let text = String(node.text ?? "");
+    if (node.content) text = extractTextFromMirror(node.content);
+    if (node.type === "paragraph") text += "\n";
+    return text;
+  }
+  return "";
+}
+
+async function fetchDescription(slug: string): Promise<string> {
+  const url = `https://api.lu.ma/url?url=${encodeURIComponent(slug)}`;
+  const data = await fetchJson<{ data?: { description_mirror?: unknown } }>(url, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+  const mirror = data?.data?.description_mirror;
+  return mirror ? extractTextFromMirror(mirror) : "";
+}
+
+function normalize(entry: Record<string, any>): NormalizedEvent {
+  const ev = entry?.event ?? {};
+  const geo = ev?.geo_address_info ?? {};
+
+  return {
+    title: String(ev?.name ?? ""),
+    description: "",
+    city: String(geo?.city ?? ""),
+    latitude: ev?.coordinate?.latitude ?? null,
+    longitude: ev?.coordinate?.longitude ?? null,
+    startTime: String(ev?.start_at ?? ""),
+    endTime: String(ev?.end_at ?? ""),
+    link: `https://lu.ma/${String(ev?.url ?? "")}`,
+    cashPrize: -1,
+    tags: [],
+    participantsCount: Number(entry?.guest_count ?? 0),
+    coverUrl: String(ev?.cover_url ?? ""),
+  };
+}
+
+/**
+ * Build the Luma source.
+ *
+ * Regions default to the location resolved from `LOCATION` or `LAT`/`LNG`.
+ * To scan several cities, pass them here or extend this list.
+ */
+export async function createLumaSource(): Promise<Source> {
+  const regions = await resolveRegions();
+
+  return {
+    name: "luma",
+    async fetchEvents(ctx: SourceContext): Promise<NormalizedEvent[]> {
+      const rawByLink = new Map<string, Record<string, any>>();
+
+      for (const region of regions) {
+        ctx.log(`scanning region '${region.label}' (${region.lat}, ${region.lng})`);
+        const raw = await scrapeRegion(region, ctx);
+        for (const entry of raw) {
+          const link = `https://lu.ma/${String(entry?.event?.url ?? "")}`;
+          if (!rawByLink.has(link)) rawByLink.set(link, entry);
+        }
+      }
+
+      const entries = [...rawByLink.values()].slice(0, ctx.limit);
+      const events: NormalizedEvent[] = [];
+
+      for (let i = 0; i < entries.length; i++) {
+        const event = normalize(entries[i]!);
+        const slug = String(entries[i]?.event?.url ?? "");
+
+        if (ctx.includeDescriptions && slug) {
+          ctx.log(`description ${i + 1}/${entries.length}: ${event.title.slice(0, 50)}`);
+          event.description = await fetchDescription(slug);
+          if (i < entries.length - 1) await sleep(randomBetween(1000, 2000));
+        }
+
+        events.push(event);
+      }
+
+      return events;
+    },
+  };
+}
+
+/** Resolve the regions to scan from the environment. */
+async function resolveRegions(): Promise<Region[]> {
+  const latEnv = process.env.LAT ? Number(process.env.LAT) : NaN;
+  const lngEnv = process.env.LNG ? Number(process.env.LNG) : NaN;
+
+  if (Number.isFinite(latEnv) && Number.isFinite(lngEnv)) {
+    return [{ label: process.env.LOCATION ?? "custom", lat: latEnv, lng: lngEnv }];
+  }
+
+  const location = process.env.LOCATION;
+  if (!location) {
+    throw new Error("[luma] Set LOCATION or both LAT and LNG.");
+  }
+
+  const coords = await geocode(location);
+  if (!coords) throw new Error(`[luma] Could not geocode '${location}'.`);
+  return [{ label: location, lat: coords.lat, lng: coords.lng }];
+}

--- a/crons/src/types.ts
+++ b/crons/src/types.ts
@@ -1,0 +1,51 @@
+// Shared types for the cron scrapers.
+//
+// A "source" is anything that can produce hackathon events (Luma, Devpost,
+// MLH, ...). Each source normalizes its own data into `NormalizedEvent` so the
+// runner can dedup and push everything through a single pipeline.
+
+/** An event normalized to the shape the hackathons API expects. */
+export type NormalizedEvent = {
+  title: string;
+  description: string;
+  city: string;
+  latitude: number | null;
+  longitude: number | null;
+  /** ISO 8601 start timestamp. */
+  startTime: string;
+  /** ISO 8601 end timestamp. */
+  endTime: string;
+  /** Canonical, de-dup key. Must be stable for a given event. */
+  link: string;
+  /** Cash prize in USD, or -1 when unknown. */
+  cashPrize: number;
+  tags: string[];
+  participantsCount: number;
+  coverUrl: string;
+};
+
+/** Context handed to every source at fetch time. */
+export type SourceContext = {
+  /** Max events the source should return this run. */
+  limit: number;
+  /** Base delay (seconds) between paginated requests; sources add jitter. */
+  delay: number;
+  /** Only keep events starting on/after this date. */
+  after?: Date;
+  /** Only keep events starting on/before this date. */
+  before?: Date;
+  /** Free-text query filter, when the source supports it. */
+  query?: string;
+  /** Whether to fetch full descriptions (can be slow / extra requests). */
+  includeDescriptions: boolean;
+  /** Structured logger scoped to the source. */
+  log: (message: string) => void;
+};
+
+/** A pluggable data source. Add a new one by implementing this interface. */
+export type Source = {
+  /** Stable identifier, e.g. "luma". Used in logs and config. */
+  readonly name: string;
+  /** Fetch and normalize events for this run. */
+  fetchEvents(ctx: SourceContext): Promise<NormalizedEvent[]>;
+};

--- a/crons/tsconfig.json
+++ b/crons/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "types": ["bun"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What

Adds a `crons/` package: scheduled scrapers that discover hackathons from external sources and push them into the directory API.

Clean **Source** abstraction — the runner handles `fetch → dedup → push → Discord notify`, so adding a source is one file + one registry line.

### Sources
- **luma** — Luma discovery API, scanned by geolocation (`LOCATION`/`LAT`/`LNG`).
- **ethglobal** — parses the `ethglobal.com/events` RSC payload in a single request, keeps `type=hackathon` (status filterable, default `future`), enriches cover/description from each event page's `og:*` tags.

### Layout
```
crons/src/
  index.ts        # runner
  config.ts       # env-driven config
  types.ts        # NormalizedEvent + Source interface
  lib/            # http, geocode, push (/exists dedup + POST), notify
  sources/        # index (registry) + luma + ethglobal
```

## Deploy
Deployed as a Railway cron service (`crons`) in the `hackathonatlas.com` project, root directory `crons`, running `SOURCES=ethglobal` every 4h. The existing Luma cron is untouched.

## Verified
- `tsc --noEmit` passes
- Dry-run against ethglobal returns the 3 upcoming hackathons with correct location, geocoded coords, dates, stable cover images and descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)