### PR TITLE
feat(crons): add Devpost scraper source

### DIFF
--- a/crons/.env.example
+++ b/crons/.env.example
@@ -1,7 +1,7 @@
 # --- Which sources to run ---------------------------------------------------
 # Comma-separated source names (see src/sources/index.ts). Empty = run all.
-# Available: luma, ethglobal
-SOURCES=luma,ethglobal
+# Available: luma, ethglobal, dorahacks, devfolio, mlh, devpost
+SOURCES=luma,ethglobal,dorahacks,devfolio,mlh,devpost
 
 # --- Luma source ------------------------------------------------------------
 # Location to scan. Either a free-text location (geocoded via Nominatim)...
@@ -14,6 +14,11 @@ LOCATION="Paris, France"
 # Which event statuses to keep (comma-separated). Default: future.
 # Options: future, finished, cancelled
 ETHGLOBAL_STATUSES=future
+
+# --- Devpost source ---------------------------------------------------------
+# Which open states to keep (comma-separated). Default: upcoming,open.
+# Options: upcoming, open, ended
+DEVPOST_STATUSES=upcoming,open
 
 # --- Fetch tuning -----------------------------------------------------------
 LIMIT=20                 # max events per source

--- a/crons/README.md
+++ b/crons/README.md
@@ -55,6 +55,7 @@ Everything is configured via environment variables — see
 | `luma`      | Luma discovery API, scanned by geolocation (`LOCATION`/`LAT`/`LNG`). | Fetches descriptions from the per-event API. |
 | `ethglobal` | ETHGlobal `/events` RSC payload — one request lists every event. | Keeps `type=hackathon`; filter statuses with `ETHGLOBAL_STATUSES` (default `future`). Cover/description come from each event page's `og:*` tags. Prize pool isn't reliably exposed, so `cashPrize` is `-1`. |
 | `mlh`       | MLH `/seasons/<year>/events` Inertia payload — one request lists every event. | Season defaults to the current one (rolls over in August); override with `MLH_SEASON`. Filter statuses with `MLH_STATUSES` (default `pending,in_progress`). Links to each hackathon's own site; descriptions come from that site's `og:description`. Prize pool isn't exposed, so `cashPrize` is `-1`. |
+| `devpost`   | Devpost public `/api/hackathons` JSON API, paginated (9/page). | Filter open states with `DEVPOST_STATUSES` (default `upcoming,open`). Human date ranges are parsed to ISO; cover/description come from each hackathon page's `og:*` tags. Only `$` prizes are treated as USD (others → `-1`). |
 
 ## Adding a new source
 

--- a/crons/src/sources/devpost.ts
+++ b/crons/src/sources/devpost.ts
@@ -1,0 +1,258 @@
+// Devpost (devpost.com) source.
+//
+// Devpost exposes a clean public JSON API at `/api/hackathons` that lists every
+// hackathon with pagination (9 per page). One request per page yields title,
+// location, dates (as a human string), prize, themes and registration counts.
+// Cover image and full description come from each hackathon page's `og:*` tags.
+
+import { geocode } from "../lib/geocode.js";
+import { fetchJson, randomBetween, sleep, USER_AGENT } from "../lib/http.js";
+import type { NormalizedEvent, Source, SourceContext } from "../types.js";
+
+const API_URL = "https://devpost.com/api/hackathons";
+const PER_PAGE = 9; // Devpost's fixed page size.
+const MAX_PAGES = 30;
+
+/** Open states to keep. Override with DEVPOST_STATUSES (comma-separated). */
+const DEFAULT_STATUSES = ["upcoming", "open"];
+
+/** Shape of a hackathon entry in the Devpost API (subset we use). */
+type DevpostHackathon = {
+  id: number;
+  title: string;
+  displayed_location?: { location?: string } | null;
+  open_state: string; // "upcoming" | "open" | "ended"
+  thumbnail_url?: string | null;
+  url: string;
+  submission_period_dates?: string | null; // e.g. "Aug 17 - Sep 03, 2026"
+  themes?: Array<{ name: string }> | null;
+  prize_amount?: string | null; // HTML: "$<span data-currency-value>40,500</span>"
+  registrations_count?: number | null;
+  organization_name?: string | null;
+};
+
+type DevpostResponse = {
+  hackathons?: DevpostHackathon[];
+  meta?: { total_count?: number; per_page?: number };
+};
+
+const MONTHS: Record<string, number> = {
+  jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+  jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+};
+
+/**
+ * Parse Devpost's human date range into ISO start/end timestamps.
+ *
+ * Formats seen: "Aug 14 - 16, 2026", "Aug 17 - Sep 03, 2026",
+ * "Sep 14 - Oct 01, 2026". The trailing year belongs to the end date; when the
+ * start month is later than the end month the range crosses New Year, so the
+ * start year is one less (e.g. "Dec 28 - Jan 03, 2027").
+ */
+function parseDateRange(
+  raw: string,
+): { startTime: string; endTime: string } | null {
+  const [leftRaw, rightRaw] = raw.split(" - ");
+  if (!leftRaw || !rightRaw) return null;
+
+  const left = leftRaw.trim().split(/\s+/); // ["Aug", "14"]
+  const startMonth = MONTHS[left[0]!.slice(0, 3).toLowerCase()];
+  const startDay = Number(left[1]);
+  if (startMonth === undefined || !Number.isFinite(startDay)) return null;
+
+  const yearMatch = rightRaw.match(/(\d{4})/);
+  if (!yearMatch) return null;
+  const endYear = Number(yearMatch[1]);
+
+  // Right side is either "16, 2026" (day only) or "Sep 03, 2026" (month + day).
+  const rightBody = rightRaw.replace(/,?\s*\d{4}\s*$/, "").trim();
+  const rightParts = rightBody.split(/\s+/);
+  let endMonth = startMonth;
+  let endDay: number;
+  if (rightParts.length >= 2) {
+    endMonth = MONTHS[rightParts[0]!.slice(0, 3).toLowerCase()] ?? startMonth;
+    endDay = Number(rightParts[1]);
+  } else {
+    endDay = Number(rightParts[0]);
+  }
+  if (!Number.isFinite(endDay)) return null;
+
+  const startYear = startMonth > endMonth ? endYear - 1 : endYear;
+
+  const start = new Date(Date.UTC(startYear, startMonth, startDay, 0, 0, 0));
+  const end = new Date(Date.UTC(endYear, endMonth, endDay, 23, 59, 59));
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+
+  return { startTime: start.toISOString(), endTime: end.toISOString() };
+}
+
+/**
+ * Parse the prize amount into USD. `prize_amount` is HTML like
+ * `$<span data-currency-value>40,500</span>`. Only `$` amounts are treated as
+ * USD; other currencies (€, £, ...) return -1 to avoid mislabelling.
+ */
+function parsePrize(raw: string | null | undefined): number {
+  if (!raw) return -1;
+  const text = raw.replace(/<[^>]*>/g, "").trim(); // strip tags -> "$40,500"
+  if (!text.startsWith("$")) return -1;
+  const digits = text.replace(/[^0-9]/g, "");
+  if (!digits) return -1;
+  const value = Number(digits);
+  return Number.isFinite(value) && value > 0 ? value : -1;
+}
+
+/** A location is "online" when Devpost has no venue or literally says "Online". */
+function isOnline(location: string): boolean {
+  return !location || location.trim().toLowerCase() === "online";
+}
+
+/** Normalize a protocol-relative Devpost image URL to an absolute https one. */
+function absoluteUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  if (url.startsWith("//")) return `https:${url}`;
+  return url;
+}
+
+/** Fetch a hackathon page and pull the stable og:image / og:description. */
+async function fetchMeta(
+  pageUrl: string,
+): Promise<{ coverUrl: string; description: string }> {
+  try {
+    const resp = await fetch(pageUrl, { headers: { "User-Agent": USER_AGENT } });
+    const html = await resp.text();
+    const og = (prop: string) =>
+      html.match(
+        new RegExp(`<meta property="og:${prop}" content="([^"]*)"`, "i"),
+      )?.[1] ?? "";
+    const decode = (s: string) =>
+      s
+        .replace(/&amp;/g, "&")
+        .replace(/&#39;/g, "'")
+        .replace(/&quot;/g, '"')
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">");
+    return {
+      coverUrl: og("image"),
+      description: decode(og("description")),
+    };
+  } catch {
+    return { coverUrl: "", description: "" };
+  }
+}
+
+function resolveStatuses(): string[] {
+  const raw = process.env.DEVPOST_STATUSES;
+  if (!raw) return DEFAULT_STATUSES;
+  return raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+async function fetchPage(
+  status: string,
+  page: number,
+  query?: string,
+): Promise<DevpostResponse> {
+  const params = new URLSearchParams({ page: String(page) });
+  params.append("status[]", status);
+  if (query) params.set("search", query);
+
+  const data = await fetchJson<DevpostResponse>(
+    `${API_URL}?${params.toString()}`,
+    { headers: { "User-Agent": USER_AGENT } },
+  );
+  return data ?? {};
+}
+
+export async function createDevpostSource(): Promise<Source> {
+  const statuses = resolveStatuses();
+
+  return {
+    name: "devpost",
+    async fetchEvents(ctx: SourceContext): Promise<NormalizedEvent[]> {
+      // 1. Collect raw hackathons across the selected statuses, deduped by id.
+      const rawById = new Map<number, DevpostHackathon>();
+
+      for (const status of statuses) {
+        for (let page = 1; page <= MAX_PAGES; page++) {
+          if (rawById.size >= ctx.limit) break;
+          ctx.log(`fetching status='${status}' page ${page}`);
+          const data = await fetchPage(status, page, ctx.query);
+          const items = data.hackathons ?? [];
+          if (!items.length) break;
+
+          for (const h of items) {
+            const dates = h.submission_period_dates
+              ? parseDateRange(h.submission_period_dates)
+              : null;
+            const start = dates ? new Date(dates.startTime) : null;
+            if (ctx.after && start && start < ctx.after) continue;
+            if (ctx.before && start && start > ctx.before) continue;
+            if (!rawById.has(h.id)) rawById.set(h.id, h);
+          }
+
+          const total = data.meta?.total_count ?? 0;
+          if (page * PER_PAGE >= total) break;
+
+          const jitter = ctx.delay + randomBetween(0.5, 1.5);
+          await sleep(jitter * 1000);
+        }
+      }
+
+      const selected = [...rawById.values()].slice(0, ctx.limit);
+      ctx.log(`kept ${selected.length} hackathons (statuses: ${statuses.join(", ")})`);
+
+      // 2. Normalize, enriching cover/description + geocoding as needed.
+      const events: NormalizedEvent[] = [];
+      for (let i = 0; i < selected.length; i++) {
+        const h = selected[i]!;
+        const location = h.displayed_location?.location ?? "";
+        const online = isOnline(location);
+        const dates = h.submission_period_dates
+          ? parseDateRange(h.submission_period_dates)
+          : null;
+
+        let latitude: number | null = null;
+        let longitude: number | null = null;
+        if (!online && location) {
+          const coords = await geocode(location);
+          if (coords) {
+            latitude = coords.lat;
+            longitude = coords.lng;
+          }
+          await sleep(randomBetween(1000, 1500)); // be gentle with Nominatim
+        }
+
+        let coverUrl = absoluteUrl(h.thumbnail_url);
+        let description = "";
+        if (ctx.includeDescriptions) {
+          ctx.log(`enriching ${i + 1}/${selected.length}: ${h.title.slice(0, 50)}`);
+          const meta = await fetchMeta(h.url);
+          if (meta.coverUrl) coverUrl = meta.coverUrl;
+          if (meta.description) description = meta.description;
+          if (i < selected.length - 1) await sleep(randomBetween(800, 1500));
+        }
+
+        const themeTags = (h.themes ?? []).map((t) => t.name);
+
+        events.push({
+          title: h.title,
+          description,
+          city: online ? "Online" : location,
+          latitude,
+          longitude,
+          startTime: dates?.startTime ?? "",
+          endTime: dates?.endTime ?? "",
+          link: h.url,
+          cashPrize: parsePrize(h.prize_amount),
+          tags: ["devpost", online ? "online" : "in-person", ...themeTags],
+          participantsCount: Number(h.registrations_count ?? 0),
+          coverUrl,
+        });
+      }
+
+      return events;
+    },
+  };
+}

--- a/crons/src/sources/index.ts
+++ b/crons/src/sources/index.ts
@@ -8,6 +8,7 @@
 
 import type { Source } from "../types.js";
 import { createDevfolioSource } from "./devfolio.js";
+import { createDevpostSource } from "./devpost.js";
 import { createDoraHacksSource } from "./dorahacks.js";
 import { createEthGlobalSource } from "./ethglobal.js";
 import { createLumaSource } from "./luma.js";
@@ -22,7 +23,7 @@ export const SOURCE_REGISTRY: Record<string, SourceFactory> = {
   dorahacks: createDoraHacksSource,
   devfolio: createDevfolioSource,
   mlh: createMlhSource,
-  // devpost: createDevpostSource,
+  devpost: createDevpostSource,
 };
 
 /** Instantiate the sources selected by config (empty selection = all). */


### PR DESCRIPTION
## Summary
Adds a **Devpost** scraper on the same `Source` interface as the existing `luma` and `ethglobal` sources.

Built on Devpost's public JSON API (`https://devpost.com/api/hackathons`):
- Paginated fetch (9/page), stops via `meta.total_count`
- Open states filtered with `DEVPOST_STATUSES` (default `upcoming,open`), deduped by id
- Human date ranges (`"Aug 17 - Sep 03, 2026"`) parsed to ISO — handles cross-month and cross-year
- In-person venues geocoded via Nominatim; `"Online"` → online
- Cover image + description pulled from each hackathon page's `og:*` tags (with HTML-entity decoding)
- Only `$` prizes treated as USD (other currencies → `-1`)
- Tags: `devpost`, `online`/`in-person`, plus Devpost themes

## Changes
- `crons/src/sources/devpost.ts` — new source
- `crons/src/sources/index.ts` — registered in the registry
- `crons/.env.example` — `DEVPOST_STATUSES` + `devpost` in `SOURCES`
- `crons/README.md` — sources table entry

## Testing
- `bun run check-types` passes
- Live dry-run (`SOURCES=devpost`) normalizes events correctly (dates, prizes, covers, descriptions, tags)
- `LIMIT=200` dry-run kept **170** hackathons (~107 upcoming + ~63 open), confirming full pagination
- Date parser edge cases validated, including cross-year (`Dec 28 - Jan 03, 2027`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)