### PR TITLE
feat(crons): back Devfolio source with Hasura GraphQL archive

### DIFF
--- a/crons/src/sources/devfolio.ts
+++ b/crons/src/sources/devfolio.ts
@@ -1,195 +1,179 @@
 // Devfolio (devfolio.co) source.
 //
-// Devfolio is a Next.js site. The /hackathons page ships its full listing in the
-// `__NEXT_DATA__` payload, bucketed into open / upcoming / past arrays — so one
-// request yields every listed hackathon (name, slug, dates, online flag,
-// participants). Those listing entries are sparse (no city, cover or
-// description), so we enrich each kept hackathon once from its microsite
-// (`<slug>.devfolio.co`), whose `__NEXT_DATA__` header carries city, cover image
-// and description.
+// Devfolio's backend is a public Hasura GraphQL API. Its `hackathons` table is
+// readable anonymously and carries the rich fields we need (name, dates, city,
+// full description, ...) directly — so one paginated query walks the entire
+// archive (~2k events, back to 2019) without any per-event page fetches. The
+// anonymous role caps each request at 20 rows, so we page with limit/offset,
+// ordered by `ends_at` descending (upcoming first, then most-recent past).
+//
+// The only field the GraphQL API does not expose is the cover image, so we
+// optionally fetch it from each hackathon's microsite (`<slug>.devfolio.co`)
+// when descriptions/enrichment are requested (INCLUDE_DESCRIPTIONS).
 
-import { geocode } from "../lib/geocode.js";
+import { geocode, type Coordinates } from "../lib/geocode.js";
 import { randomBetween, sleep, USER_AGENT } from "../lib/http.js";
 import type { NormalizedEvent, Source, SourceContext } from "../types.js";
 
-const LISTING_URL = "https://devfolio.co/hackathons";
+const GQL_URL = "https://api.devfolio.co/v1/graphql";
+const PAGE_SIZE = 20; // anonymous role hard-caps rows per request at 20
+const DEFAULT_MAX_PAGES = 200; // safety bound (~4k events)
 
-/** Listing buckets to keep. Override with DEVFOLIO_STATUSES (comma-separated). */
-const DEFAULT_STATUSES = ["open", "upcoming"];
+/** Fields the anonymous role exposes on the `hackathons` table (subset). */
+const GQL_FIELDS = [
+  "uuid",
+  "slug",
+  "name",
+  "type",
+  "starts_at",
+  "ends_at",
+  "is_online",
+  "city",
+  "country",
+  "location",
+  "tagline",
+  "desc",
+  "participants_count",
+].join(" ");
 
-/** Maps a status name to its array key in the listing payload. */
-const STATUS_KEYS: Record<string, string> = {
-  open: "open_hackathons",
-  upcoming: "upcoming_hackathons",
-  past: "past_hackathons",
-  featured: "featured_hackathons",
-};
-
-/** Shape of a listing entry inside the /hackathons payload (subset we use). */
-type ListEntry = {
+type GqlHackathon = {
   uuid: string;
   slug: string;
   name: string;
   type: string; // "HACKATHON" | ...
-  starts_at: string;
-  ends_at: string;
+  starts_at: string | null;
+  ends_at: string | null;
   is_online: boolean;
-  participants_count?: number;
+  city: string | null;
+  country: string | null;
+  location: string | null;
+  tagline: string | null;
+  desc: string | null;
+  participants_count: number | null;
 };
 
-/** Shape of a microsite header hackathon (subset we use). */
-type MicrositeHackathon = {
-  city?: string | null;
-  country?: string | null;
-  location?: string | null;
-  tagline?: string | null;
-  desc?: string | null;
-  cover_img?: string | null;
-  is_online?: boolean;
-};
-
-/** Pull and parse the `__NEXT_DATA__` JSON blob out of a Devfolio HTML page. */
-function parseNextData(html: string): any {
-  const m = html.match(
-    /<script id="__NEXT_DATA__" type="application\/json">(.*?)<\/script>/s,
-  );
-  if (!m) return null;
-  try {
-    return JSON.parse(m[1]!);
-  } catch {
-    return null;
+/** Fetch one page of hackathons ordered by end date (newest first). */
+async function fetchPage(offset: number): Promise<GqlHackathon[]> {
+  const query = `query Hackathons($limit:Int!,$offset:Int!){ hackathons(limit:$limit, offset:$offset, order_by:{ends_at:desc_nulls_last}){ ${GQL_FIELDS} } }`;
+  const resp = await fetch(GQL_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+    body: JSON.stringify({ query, variables: { limit: PAGE_SIZE, offset } }),
+  });
+  if (!resp.ok) throw new Error(`[devfolio] graphql ${resp.status}`);
+  const json = (await resp.json()) as {
+    data?: { hackathons?: GqlHackathon[] };
+    errors?: Array<{ message: string }>;
+  };
+  if (json.errors?.length) {
+    throw new Error(`[devfolio] graphql: ${json.errors[0]!.message}`);
   }
+  return json.data?.hackathons ?? [];
 }
 
-/** Find the query whose data holds the hackathon listing buckets. */
-function findListingData(nextData: any): Record<string, ListEntry[]> | null {
-  const queries = nextData?.props?.pageProps?.dehydratedState?.queries ?? [];
-  for (const q of queries) {
-    const data = q?.state?.data;
-    if (data && typeof data === "object" && Array.isArray(data.open_hackathons)) {
-      return data as Record<string, ListEntry[]>;
-    }
-  }
-  return null;
+/** Geocoding cache keyed by location string — many events share a city. */
+const geocodeCache = new Map<string, Coordinates | null>();
+
+async function geocodeCached(location: string): Promise<Coordinates | null> {
+  const key = location.trim().toLowerCase();
+  if (geocodeCache.has(key)) return geocodeCache.get(key)!;
+  const coords = await geocode(location);
+  geocodeCache.set(key, coords);
+  await sleep(randomBetween(1100, 1400)); // Nominatim: ~1 req/s, only on misses
+  return coords;
 }
 
-/** Fetch a microsite page and pull the enriched hackathon header. */
-async function fetchMicrosite(slug: string): Promise<MicrositeHackathon | null> {
+/** Fetch a microsite page and pull the cover image (og:image / cover_img). */
+async function fetchCover(slug: string): Promise<string> {
   try {
     const resp = await fetch(`https://${slug}.devfolio.co/`, {
       headers: { "User-Agent": USER_AGENT },
     });
-    if (!resp.ok) return null;
-    const nextData = parseNextData(await resp.text());
-    const queries = nextData?.props?.pageProps?.dehydratedState?.queries ?? [];
-    for (const q of queries) {
-      const data = q?.state?.data;
-      const list = Array.isArray(data) ? data : [];
-      for (const item of list) {
-        const hk = item?.hackathons?.[0];
-        if (hk) return hk as MicrositeHackathon;
-      }
-    }
-    return null;
+    if (!resp.ok) return "";
+    const html = await resp.text();
+    return (
+      html.match(/<meta property="og:image" content="([^"]*)"/i)?.[1] ?? ""
+    );
   } catch {
-    return null;
+    return "";
   }
 }
 
-function resolveStatuses(): string[] {
-  const raw = process.env.DEVFOLIO_STATUSES;
-  if (!raw) return DEFAULT_STATUSES;
-  return raw
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-}
-
 export async function createDevfolioSource(): Promise<Source> {
-  const statuses = resolveStatuses();
+  const maxPages = Math.max(
+    1,
+    Number(process.env.DEVFOLIO_MAX_PAGES) || DEFAULT_MAX_PAGES,
+  );
 
   return {
     name: "devfolio",
     async fetchEvents(ctx: SourceContext): Promise<NormalizedEvent[]> {
-      ctx.log(`fetching ${LISTING_URL}`);
-      const resp = await fetch(LISTING_URL, {
-        headers: { "User-Agent": USER_AGENT },
-      });
-      if (!resp.ok) throw new Error(`[devfolio] listing page ${resp.status}`);
-
-      const listing = findListingData(parseNextData(await resp.text()));
-      if (!listing) throw new Error("[devfolio] could not parse listing payload");
-
-      // Collect entries from the selected buckets, deduped by slug (a hackathon
-      // can appear in more than one bucket, e.g. featured + open).
-      const bySlug = new Map<string, ListEntry>();
-      for (const status of statuses) {
-        const key = STATUS_KEYS[status];
-        if (!key) {
-          ctx.log(`unknown status '${status}', skipping`);
-          continue;
-        }
-        for (const e of listing[key] ?? []) {
-          if (e?.slug && !bySlug.has(e.slug)) bySlug.set(e.slug, e);
-        }
-      }
-      ctx.log(`parsed ${bySlug.size} hackathons (statuses: ${statuses.join(", ")})`);
-
       const query = ctx.query?.toLowerCase();
-      const kept = [...bySlug.values()].filter((e) => {
-        if (e.type && e.type !== "HACKATHON") return false;
-        const start = new Date(e.starts_at);
-        if (ctx.after && start < ctx.after) return false;
-        if (ctx.before && start > ctx.before) return false;
-        if (query && !e.name.toLowerCase().includes(query)) return false;
-        return true;
-      });
+      const kept: GqlHackathon[] = [];
 
-      ctx.log(`kept ${kept.length} after filtering`);
-      const selected = kept.slice(0, ctx.limit);
+      // 1. Page through the archive until we have enough or run dry.
+      for (let page = 0; page < maxPages && kept.length < ctx.limit; page++) {
+        const rows = await fetchPage(page * PAGE_SIZE);
+        if (!rows.length) break;
+
+        for (const e of rows) {
+          if (e.type && e.type !== "HACKATHON") continue;
+          if (!e.starts_at) continue;
+          const start = new Date(e.starts_at);
+          if (ctx.after && start < ctx.after) continue;
+          if (ctx.before && start > ctx.before) continue;
+          if (query && !e.name.toLowerCase().includes(query)) continue;
+          kept.push(e);
+          if (kept.length >= ctx.limit) break;
+        }
+
+        ctx.log(`page ${page + 1}: ${kept.length} kept so far`);
+        if (kept.length < ctx.limit) await sleep(randomBetween(200, 500));
+      }
+
+      ctx.log(`collected ${kept.length} hackathons`);
       const events: NormalizedEvent[] = [];
 
-      for (let i = 0; i < selected.length; i++) {
-        const e = selected[i]!;
-        ctx.log(`enriching ${i + 1}/${selected.length}: ${e.name.slice(0, 50)}`);
-        const meta = await fetchMicrosite(e.slug);
-
-        const online = e.is_online || meta?.is_online || !meta?.city;
-        const cityName = meta?.city ?? "";
-        const countryName = meta?.country ?? "";
+      // 2. Normalize (geocode physical events; optionally fetch cover images).
+      for (let i = 0; i < kept.length; i++) {
+        const e = kept[i]!;
+        const online = e.is_online || !e.city;
+        const cityName = e.city ?? "";
+        const countryName = e.country ?? "";
 
         let latitude: number | null = null;
         let longitude: number | null = null;
         if (!online && cityName) {
           const q =
-            meta?.location || (countryName ? `${cityName}, ${countryName}` : cityName);
-          const coords = await geocode(q);
+            e.location || (countryName ? `${cityName}, ${countryName}` : cityName);
+          const coords = await geocodeCached(q);
           if (coords) {
             latitude = coords.lat;
             longitude = coords.lng;
           }
-          await sleep(randomBetween(1000, 1500)); // be gentle with Nominatim
         }
 
-        const description =
-          (ctx.includeDescriptions ? meta?.desc : null) ?? meta?.tagline ?? "";
+        let coverUrl = "";
+        if (ctx.includeDescriptions) {
+          ctx.log(`enriching ${i + 1}/${kept.length}: ${e.name.slice(0, 50)}`);
+          coverUrl = await fetchCover(e.slug);
+          if (i < kept.length - 1) await sleep(randomBetween(600, 1200));
+        }
 
         events.push({
           title: e.name,
-          description,
+          description: e.desc || e.tagline || "",
           city: online ? "Online" : cityName,
           latitude,
           longitude,
-          startTime: e.starts_at,
-          endTime: e.ends_at,
+          startTime: e.starts_at ?? "",
+          endTime: e.ends_at ?? "",
           link: `https://${e.slug}.devfolio.co`,
           cashPrize: -1, // prize amounts aren't exposed in the payload
           tags: ["devfolio", online ? "online" : "in-person"],
           participantsCount: Number(e.participants_count ?? 0),
-          coverUrl: meta?.cover_img ?? "",
+          coverUrl,
         });
-
-        if (i < selected.length - 1) await sleep(randomBetween(800, 1500));
       }
 
       return events;


### PR DESCRIPTION
Rewrites the Devfolio source to pull from Devfolio's public **Hasura GraphQL API** (`api.devfolio.co/v1/graphql`) instead of scraping the `/hackathons` SSR listing.

## Why
The SSR listing only ships ~24 open/upcoming hackathons. The GraphQL `hackathons` table is readable anonymously and exposes name, dates, city, country, location and **full description** directly — so a paginated query walks the **entire archive (~2k events, back to 2019)** with no per-event page fetches.

## How
- **Pagination**: anonymous role caps rows at 20/request, so we page with `limit`/`offset`, ordered by `ends_at desc` (upcoming first, then most-recent past). Stops at `LIMIT` kept events, an empty page, or `DEVFOLIO_MAX_PAGES`.
- **Geocoding**: cached by location string (many events share a city) and throttled (~1 req/s, only on cache misses) so bulk runs stay gentle on Nominatim.
- **Covers**: the only field GraphQL omits; fetched from the microsite (`<slug>.devfolio.co` og:image) only when `INCLUDE_DESCRIPTIONS` is set.
- Stable `link` (`https://<slug>.devfolio.co`) unchanged, so it dedups against events already in the directory.

## Verification
- `bun run check-types` passes.
- Dry-run pages the archive and emits normalized events with full descriptions, dates and geocoded coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)