### PR TITLE
feat(crons): add Photon geocoder option + clean Devpost venues

### DIFF
--- a/crons/src/lib/geocode.ts
+++ b/crons/src/lib/geocode.ts
@@ -1,14 +1,26 @@
-// Geocoding via Nominatim (OpenStreetMap). Shared by sources that only expose
-// a free-text location and need coordinates.
+// Geocoding for sources that only expose a free-text location.
+//
+// Two providers, both OpenStreetMap-based and keyless:
+//   - nominatim (default): OSM's own server. Strict — max ~1 req/s, bulk use
+//     is against its usage policy. Fine for the small per-run cron.
+//   - photon (komoot): tolerates higher throughput and resolves venue names
+//     better; use it for large backfills. Select with GEOCODER=photon.
 
 import { fetchJson, USER_AGENT } from "./http.js";
 
 const NOMINATIM_API = "https://nominatim.openstreetmap.org/search";
+const PHOTON_API = "https://photon.komoot.io/api/";
 
 export type Coordinates = { lat: number; lng: number };
 
-/** Resolve a free-text location to coordinates, or null if not found. */
-export async function geocode(location: string): Promise<Coordinates | null> {
+/** Which geocoding provider to use (GEOCODER env, default nominatim). */
+function provider(): "nominatim" | "photon" {
+  return process.env.GEOCODER?.trim().toLowerCase() === "photon"
+    ? "photon"
+    : "nominatim";
+}
+
+async function geocodeNominatim(location: string): Promise<Coordinates | null> {
   const params = new URLSearchParams({ format: "json", q: location, limit: "1" });
   const data = await fetchJson<Array<{ lat: string; lon: string }>>(
     `${NOMINATIM_API}?${params.toString()}`,
@@ -16,4 +28,27 @@ export async function geocode(location: string): Promise<Coordinates | null> {
   );
   if (!data || !data.length) return null;
   return { lat: Number(data[0]!.lat), lng: Number(data[0]!.lon) };
+}
+
+type PhotonResponse = {
+  features?: Array<{ geometry?: { coordinates?: [number, number] } }>;
+};
+
+async function geocodePhoton(location: string): Promise<Coordinates | null> {
+  const params = new URLSearchParams({ q: location, limit: "1" });
+  const data = await fetchJson<PhotonResponse>(
+    `${PHOTON_API}?${params.toString()}`,
+    { headers: { "User-Agent": USER_AGENT } },
+  );
+  // Photon returns GeoJSON: coordinates are [longitude, latitude].
+  const coords = data?.features?.[0]?.geometry?.coordinates;
+  if (!coords || coords.length < 2) return null;
+  return { lat: Number(coords[1]), lng: Number(coords[0]) };
+}
+
+/** Resolve a free-text location to coordinates, or null if not found. */
+export async function geocode(location: string): Promise<Coordinates | null> {
+  return provider() === "photon"
+    ? geocodePhoton(location)
+    : geocodeNominatim(location);
 }

--- a/crons/src/sources/devpost.ts
+++ b/crons/src/sources/devpost.ts
@@ -148,6 +148,18 @@ function isOnline(location: string): boolean {
   return !location || location.trim().toLowerCase() === "online";
 }
 
+/**
+ * Strip the "and Online" / "Online and" bits from hybrid venues so both the
+ * displayed city and the geocode query are clean (e.g. "Santa Clara Convention
+ * Center and Online" -> "Santa Clara Convention Center").
+ */
+function cleanLocation(location: string): string {
+  return location
+    .replace(/\s*(?:,|-|&|and)\s*online\s*$/i, "")
+    .replace(/^\s*online\s*(?:,|-|&|and)\s*/i, "")
+    .trim();
+}
+
 /** Normalize a protocol-relative Devpost image URL to an absolute https one. */
 function absoluteUrl(url: string | null | undefined): string {
   if (!url) return "";
@@ -270,8 +282,9 @@ export async function createDevpostSource(): Promise<Source> {
       const events: NormalizedEvent[] = [];
       for (let i = 0; i < selected.length; i++) {
         const h = selected[i]!;
-        const location = h.displayed_location?.location ?? "";
-        const online = isOnline(location);
+        const rawLocation = h.displayed_location?.location ?? "";
+        const online = isOnline(rawLocation);
+        const location = online ? rawLocation : cleanLocation(rawLocation);
         const dates = h.submission_period_dates
           ? parseDateRange(h.submission_period_dates)
           : null;


### PR DESCRIPTION
## Why
Nominatim's public server forbids bulk geocoding and caps at ~1 req/s, so it can't back large backfills. Add a keyless, OSM-based alternative.

## Changes
- **`GEOCODER=photon`** selects Photon (komoot) instead of Nominatim in the shared geocode lib. Photon tolerates higher throughput and resolves venue names better. Default stays `nominatim`, so luma/ethglobal/devfolio behaviour is unchanged.
- **Devpost venue cleanup** — hybrid strings like `"Santa Clara Convention Center and Online"` are stripped of the `and Online` bits for both the displayed city and the geocode query.

## Testing
- `bun run check-types` passes
- Photon via `GEOCODER=photon`, with cleanup:
  - `"Santa Clara Convention Center and Online"` → `Santa Clara Convention Center` → 37.40, -121.98
  - `"Munich, Germany"` → 48.14, 11.58
  - `"Online and San Francisco, CA"` → `San Francisco, CA` → 37.79, -122.41

🤖 Generated with [Claude Code](https://claude.com/claude-code)