### PR TITLE
Theme toggle: one-click switch with sliding animation + dark-mode polish

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3,6 +3,22 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* ─── Theme switch: no flashing ────────────────────────────────────────────
+   Some elements carry `transition-colors` (buttons, cards, hover targets) and
+   most don't. On a theme flip the transitioning ones lag behind the instant
+   ones, so a still-light surface briefly sits on an already-dark page and
+   reads as a bright flash. While `.theme-switching` is on `<html>` we freeze
+   every transition so the whole page changes at once — the toggle's own
+   sliding pill is exempted so its animation is preserved. */
+html.theme-switching *,
+html.theme-switching *::before,
+html.theme-switching *::after {
+  transition: none !important;
+}
+html.theme-switching [data-theme-slider] {
+  transition: transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1) !important;
+}
+
 * {
   box-sizing: border-box;
   margin: 0;
@@ -161,8 +177,10 @@ a {
 .dark .bg-\[\#FAFAFA\] { background-color: #161618 !important; }
 .dark .bg-\[\#F4F4F5\] { background-color: #26262a !important; }
 .dark .bg-\[\#EFEFEF\] { background-color: #1f1f22 !important; }
+.dark .bg-\[\#F1F1F1\] { background-color: #26262a !important; }
 .dark .bg-\[\#7A7A7A\] { background-color: #71717a !important; }
 .dark .bg-\[\#FCEFCE\] { background-color: #3a2e12 !important; }
+.dark .bg-\[\#DCFCE7\] { background-color: #14311f !important; }
 
 /* Borders */
 .dark .border-\[\#EAEAEA\] { border-color: #232326 !important; }
@@ -177,6 +195,7 @@ a {
 .dark .text-\[\#71717A\] { color: #9a9aa0 !important; }
 .dark .text-\[\#A1A1AA\] { color: #8f8f96 !important; }
 .dark .text-\[\#B45309\] { color: #f5c560 !important; }
+.dark .text-\[\#15803D\] { color: #4ade80 !important; }
 .dark .placeholder\:text-\[\#A1A1AA\]::placeholder { color: #6f6f76 !important; }
 
 /* Primary (black) surfaces invert to white with dark content */

--- a/apps/web/app/stats/page.tsx
+++ b/apps/web/app/stats/page.tsx
@@ -186,7 +186,7 @@ export default async function StatsPage() {
                   <span className="h-1.5 flex-1 overflow-hidden rounded-full bg-[#F1F1F1]">
                     <span
                       className="block h-full rounded-full"
-                      style={{ width: `${pct(s.total)}%`, backgroundColor: colorFor(s.label) }}
+                      style={{ width: `${pct(s.total)}%`, backgroundColor: "var(--foreground)" }}
                     />
                   </span>
                   <span className="w-9 shrink-0 text-right text-[13px] text-[#A1A1AA] tabular-nums">{pct(s.total)}%</span>

--- a/apps/web/app/theme-toggle.tsx
+++ b/apps/web/app/theme-toggle.tsx
@@ -10,8 +10,16 @@ export function ThemeToggle() {
   }, []);
 
   function apply(next: "light" | "dark") {
+    const root = document.documentElement;
+    // Freeze every transition so the whole page recolors in one paint — no
+    // element lags behind and flashes. Lifted on the next frame so hover
+    // transitions work again immediately after.
+    root.classList.add("theme-switching");
     setTheme(next);
-    document.documentElement.classList.toggle("dark", next === "dark");
+    root.classList.toggle("dark", next === "dark");
+    // Force the new colors to be computed while transitions are still frozen.
+    void root.offsetHeight;
+    requestAnimationFrame(() => root.classList.remove("theme-switching"));
     try {
       localStorage.setItem("theme", next);
     } catch {
@@ -19,17 +27,28 @@ export function ThemeToggle() {
     }
   }
 
+  function toggle() {
+    apply(theme === "light" ? "dark" : "light");
+  }
+
   return (
-    <div className="flex items-center gap-[2px] rounded-full border border-[#E4E4E7] p-[5px] max-[640px]:hidden">
-      <button
-        type="button"
-        onClick={() => apply("light")}
-        aria-label="Light theme"
-        aria-pressed={theme === "light"}
-        className={`flex h-[26px] w-[26px] items-center justify-center rounded-full transition-colors ${
-          theme === "light" ? "bg-[#F4F4F5]" : "hover:bg-[#FAFAFA]"
-        }`}
-      >
+    <button
+      type="button"
+      onClick={toggle}
+      role="switch"
+      aria-checked={theme === "dark"}
+      aria-label={theme === "light" ? "Switch to dark theme" : "Switch to light theme"}
+      className="relative flex items-center gap-[2px] rounded-full border border-[#E4E4E7] p-[5px] transition-colors max-[640px]:hidden"
+    >
+      {/* Sliding highlight — animates between the two icons */}
+      <span
+        aria-hidden="true"
+        data-theme-slider
+        className="pointer-events-none absolute top-[5px] left-[5px] h-[26px] w-[26px] rounded-full bg-[#F4F4F5] transition-transform duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)]"
+        style={{ transform: theme === "dark" ? "translateX(28px)" : "translateX(0)" }}
+      />
+      {/* Sun (day) */}
+      <span className="relative z-10 flex h-[26px] w-[26px] items-center justify-center">
         <svg
           width="15"
           height="15"
@@ -38,25 +57,26 @@ export function ThemeToggle() {
           stroke={theme === "light" ? "#18181B" : "#A1A1AA"}
           strokeWidth="2"
           strokeLinecap="round"
+          className="transition-colors duration-300"
           aria-hidden="true"
         >
           <circle cx="12" cy="12" r="4" />
           <path d="M12 2v2M12 20v2M4 12H2M22 12h-2M6 6L4.5 4.5M19.5 19.5L18 18M18 6l1.5-1.5M4.5 19.5L6 18" />
         </svg>
-      </button>
-      <button
-        type="button"
-        onClick={() => apply("dark")}
-        aria-label="Dark theme"
-        aria-pressed={theme === "dark"}
-        className={`flex h-[26px] w-[26px] items-center justify-center rounded-full transition-colors ${
-          theme === "dark" ? "bg-[#F4F4F5]" : "hover:bg-[#FAFAFA]"
-        }`}
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill={theme === "dark" ? "#EDEDED" : "#A1A1AA"} aria-hidden="true">
+      </span>
+      {/* Moon (night) */}
+      <span className="relative z-10 flex h-[26px] w-[26px] items-center justify-center">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill={theme === "dark" ? "#EDEDED" : "#A1A1AA"}
+          className="transition-colors duration-300"
+          aria-hidden="true"
+        >
           <path d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />
         </svg>
-      </button>
-    </div>
+      </span>
+    </button>
   );
 }


### PR DESCRIPTION
## What

Improves the day/night experience and fixes a few dark-mode color issues.

### Theme toggle
- Now a single switch: clicking **anywhere** on it flips the theme — no need to aim at the sun or moon precisely.
- The active-highlight pill **slides** between the two icons (300ms, slightly springy easing). Icon colors cross-fade.
- Accessible: `role="switch"`, `aria-checked`, dynamic `aria-label`.

### No more flash on theme change
- Only some elements had `transition-colors`, so on a theme flip they lagged behind the instant ones — a still-light surface briefly on an already-dark page read as a bright flash.
- A temporary `.theme-switching` class on `<html>` freezes all transitions for the single swap frame, so the whole page recolors at once. The toggle's own sliding pill is exempted so its animation is preserved.

### Dark-mode color fixes
- Home page: added dark remaps for the green **"New"** badge (`bg-[#DCFCE7]` / `text-[#15803D]`) — it was too bright.
- Stats page: the share-bar **track** (`bg-[#F1F1F1]`) had no dark remap and stayed near-white; added one.

### Stats share bars
- All share bars now use a **single uniform color** (via the `--foreground` token) instead of a different color per source, so they flip correctly between light (black) and dark (white).

## Test
Verified locally in both light and dark mode: `/` and `/stats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)