### PR TITLE
fix(web): persist theme across reloads

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Inter, Yrsa } from "next/font/google";
+import { cookies } from "next/headers";
 import Script from "next/script";
 import { CommandKSearch } from "./command-k-search";
 import "./globals.css";
@@ -78,13 +79,22 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Read the persisted theme server-side and render the `dark` class directly on
+  // <html>. This keeps the class in React's tree so hydration doesn't strip it
+  // (React 19 removes classes added to <html> client-side before hydration).
+  const theme = (await cookies()).get("theme")?.value;
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      className={theme === "dark" ? "dark" : undefined}
+      suppressHydrationWarning
+    >
       <head>
         <script
           dangerouslySetInnerHTML={{

--- a/apps/web/app/theme-toggle.tsx
+++ b/apps/web/app/theme-toggle.tsx
@@ -20,11 +20,16 @@ export function ThemeToggle() {
     // Force the new colors to be computed while transitions are still frozen.
     void root.offsetHeight;
     requestAnimationFrame(() => root.classList.remove("theme-switching"));
+    // Persist to a cookie so the server can render the right `dark` class on the
+    // <html> tag on the next load. Under React 19 a class added client-side to
+    // <html> is stripped during hydration, so relying on localStorage + an inline
+    // script alone loses the theme on refresh. localStorage stays as a fallback.
     try {
       localStorage.setItem("theme", next);
     } catch {
       /* ignore */
     }
+    document.cookie = `theme=${next}; path=/; max-age=31536000; SameSite=Lax`;
   }
 
   function toggle() {


### PR DESCRIPTION
## Problème

Sur hackathonatlas.com, changer le thème puis actualiser ne conservait pas le thème.

Reproduit en direct : après reload, `localStorage` valait `dark` et le script inline était présent, mais `<html>` n'avait aucune classe et le fond restait blanc.

## Cause

React 19 (avec Next 16) retire, pendant l'hydratation, la classe `dark` que le script inline ajoute à `<html>` avant l'hydratation : le HTML rendu côté serveur ne contient pas cette classe, donc React « corrige » l'écart en la supprimant. `suppressHydrationWarning` ne protège pas les attributs de l'élément racine dans React 19.

## Correctif

Faire connaître la préférence au serveur via un cookie pour qu'il rende `class="dark"` directement sur `<html>`. La classe est alors dans l'arbre React → pas de suppression à l'hydratation, pas de flash. Les pages étant déjà `force-dynamic`, aucun coût SSG.

- `theme-toggle.tsx` : le toggle écrit aussi un cookie (en plus de `localStorage`).
- `layout.tsx` : `RootLayout` devient `async`, lit le cookie via `next/headers` et pose la classe sur `<html>`.

## Notes

- Non vérifié par `tsc`/`build` (workspace sans `node_modules`), mais changements idiomatiques Next 15/16.
- Limite mineure : premier visiteur sans cookie avec OS en mode sombre peut voir un bref flash (préférence OS non pré-rendable côté serveur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)