### PR TITLE
fix(web): remove white logo border in dark mode on stats page

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -184,6 +184,7 @@ a {
 
 /* Borders */
 .dark .border-\[\#EAEAEA\] { border-color: #232326 !important; }
+.dark .border-\[\#EEEEEE\] { border-color: #232326 !important; }
 .dark .border-\[\#E4E4E7\] { border-color: #2a2a2e !important; }
 .dark .border-\[\#D4D4D8\],
 .dark .focus-within\:border-\[\#D4D4D8\]:focus-within { border-color: #3a3a3e !important; }


### PR DESCRIPTION
On the stats page, the `#EEEEEE` border around hackathon/source logos was not remapped under `.dark`, leaving a near-white outline in dark mode. This adds a dark-mode remapping so the border uses the same subtle dark color (`#232326`) as other surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)