### PR TITLE
feat(web): LLM classifier to flag fake/test hackathons

### DIFF
--- a/apps/web/app/admin/admin-review-list.tsx
+++ b/apps/web/app/admin/admin-review-list.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+
+export interface ReviewRow {
+  id: string;
+  title: string;
+  description: string | null;
+  link: string | null;
+  location: string | null;
+  startTime: string | null;
+  status: "needs_review" | "rejected";
+  confidence: number | null;
+  reason: string | null;
+  model: string | null;
+}
+
+export function AdminReviewList({ rows }: { rows: ReviewRow[] }) {
+  const [items, setItems] = useState(rows);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function moderate(id: string, action: "keep" | "reject") {
+    setBusy(id);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/moderate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id, action }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? `Request failed (${res.status})`);
+      }
+      // Remove from the queue — the decision is applied.
+      setItems((prev) => prev.filter((r) => r.id !== id));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="rounded-lg border border-[#EAEAEA] px-6 py-16 text-center text-[15px] text-[#A1A1AA]">
+        Nothing to review. 🎉
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {error && (
+        <p className="rounded-md bg-[#FEF2F2] px-3 py-2 text-[13px] text-[#DC2626]">
+          {error}
+        </p>
+      )}
+      {items.map((r) => (
+        <div
+          key={r.id}
+          className="flex flex-col gap-3 rounded-lg border border-[#EAEAEA] p-4"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={r.status} />
+            {r.confidence != null && (
+              <span className="text-[12px] text-[#A1A1AA] tabular-nums">
+                confidence {r.confidence.toFixed(2)}
+              </span>
+            )}
+            {r.model && (
+              <span className="text-[12px] text-[#A1A1AA]">· {r.model}</span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <span className="text-[16px] font-semibold text-[#18181B]">
+              {r.title}
+            </span>
+            <span className="text-[13px] text-[#71717A]">
+              {[r.location, formatDate(r.startTime)].filter(Boolean).join(" · ") ||
+                "No location/date"}
+            </span>
+          </div>
+
+          {r.reason && (
+            <p className="text-[13px] italic text-[#52525B]">
+              LLM: {r.reason}
+            </p>
+          )}
+          {r.description && (
+            <p className="line-clamp-2 text-[13px] text-[#3F3F46]">
+              {r.description}
+            </p>
+          )}
+          {r.link && (
+            <a
+              href={r.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-fit break-all text-[13px] text-[#18181B] underline underline-offset-2"
+            >
+              {r.link}
+            </a>
+          )}
+
+          <div className="mt-1 flex gap-2">
+            <button
+              onClick={() => moderate(r.id, "keep")}
+              disabled={busy === r.id}
+              className="rounded-md bg-[#15803D] px-4 py-1.5 text-[13px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              Keep
+            </button>
+            <button
+              onClick={() => moderate(r.id, "reject")}
+              disabled={busy === r.id}
+              className="rounded-md bg-[#DC2626] px-4 py-1.5 text-[13px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: ReviewRow["status"] }) {
+  const label = status === "needs_review" ? "Needs review" : "Rejected";
+  const cls =
+    status === "needs_review"
+      ? "bg-[#FEF3C7] text-[#B45309]"
+      : "bg-[#FEE2E2] text-[#DC2626]";
+  return (
+    <span
+      className={`rounded-full px-2 py-[3px] text-[11px] font-semibold ${cls}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function formatDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,0 +1,149 @@
+import { desc, inArray, sql } from "drizzle-orm";
+import { db } from "../../src/db";
+import { events } from "../../src/db/schema";
+import { isAdmin, adminSecret } from "../../src/lib/admin-auth";
+import { AdminReviewList, type ReviewRow } from "./admin-review-list";
+
+export const dynamic = "force-dynamic";
+
+const REVIEW_LIMIT = 300;
+
+export default async function AdminPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+
+  // Config guard — without a secret the page can't be secured, so refuse.
+  if (!adminSecret()) {
+    return (
+      <Shell>
+        <p className="text-[15px] text-[#B45309]">
+          ADMIN_SECRET is not configured. Set it in the environment to enable
+          the admin.
+        </p>
+      </Shell>
+    );
+  }
+
+  if (!(await isAdmin())) {
+    return (
+      <Shell>
+        <form
+          method="POST"
+          action="/api/admin/login"
+          className="flex max-w-[320px] flex-col gap-3"
+        >
+          <label className="text-[13px] font-medium text-[#3F3F46]">
+            Admin secret
+          </label>
+          <input
+            type="password"
+            name="secret"
+            autoComplete="off"
+            className="rounded-md border border-[#E4E4E7] px-3 py-2 text-[14px] outline-none focus:border-[#A1A1AA]"
+          />
+          {error && (
+            <p className="text-[13px] text-[#DC2626]">Incorrect secret.</p>
+          )}
+          <button
+            type="submit"
+            className="rounded-md bg-[#0A0A0A] px-4 py-2 text-[14px] font-medium text-white transition-opacity hover:opacity-90"
+          >
+            Sign in
+          </button>
+        </form>
+      </Shell>
+    );
+  }
+
+  const [rows, counts] = await Promise.all([
+    db
+      .select({
+        id: events.id,
+        title: events.title,
+        description: events.description,
+        link: events.link,
+        city: events.city,
+        country: events.country,
+        startTime: events.startTime,
+        status: events.classificationStatus,
+        confidence: events.classificationConfidence,
+        reason: events.classificationReason,
+        model: events.classificationModel,
+      })
+      .from(events)
+      .where(inArray(events.classificationStatus, ["needs_review", "rejected"]))
+      // needs_review (the actionable queue) first, then most recent.
+      .orderBy(
+        sql`case when ${events.classificationStatus} = 'needs_review' then 0 else 1 end`,
+        desc(events.classifiedAt),
+      )
+      .limit(REVIEW_LIMIT),
+    db
+      .select({
+        status: events.classificationStatus,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(events)
+      .groupBy(events.classificationStatus),
+  ]);
+
+  const byStatus = Object.fromEntries(counts.map((c) => [c.status, c.count]));
+  const reviewRows: ReviewRow[] = rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    description: r.description?.replace(/\s+/g, " ").trim().slice(0, 240) ?? null,
+    link: r.link,
+    location: [r.city, r.country].filter(Boolean).join(", ") || null,
+    startTime: r.startTime ? r.startTime.toISOString() : null,
+    status: r.status as "needs_review" | "rejected",
+    confidence: r.confidence,
+    reason: r.reason,
+    model: r.model,
+  }));
+
+  return (
+    <Shell>
+      <div className="mb-6 flex flex-wrap gap-4 text-[13px] text-[#52525B]">
+        <Stat label="Needs review" value={byStatus["needs_review"] ?? 0} />
+        <Stat label="Rejected" value={byStatus["rejected"] ?? 0} />
+        <Stat label="Kept" value={byStatus["kept"] ?? 0} />
+        <Stat label="Pending" value={byStatus["pending"] ?? 0} />
+      </div>
+      <AdminReviewList rows={reviewRows} />
+    </Shell>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span className="font-semibold text-[#18181B] tabular-nums">
+        {value.toLocaleString("en-US")}
+      </span>
+      <span className="text-[#A1A1AA]">{label}</span>
+    </span>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="flex min-h-screen justify-center bg-white"
+      style={{ fontFamily: "var(--font-geist), system-ui, sans-serif" }}
+    >
+      <div className="w-full max-w-[900px] px-8 py-12">
+        <h1 className="mb-1 text-[24px] font-bold tracking-[-0.02em] text-[#0A0A0A]">
+          Moderation
+        </h1>
+        <p className="mb-8 text-[14px] text-[#71717A]">
+          Review hackathons the classifier was unsure about, and correct any bad
+          auto-decisions.
+        </p>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/api/admin/login/route.ts
+++ b/apps/web/app/api/admin/login/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  ADMIN_COOKIE,
+  adminSecret,
+  secretMatches,
+} from "../../../../src/lib/admin-auth";
+
+// Accepts the /admin login form (a plain HTML POST, no JS required). On a
+// correct secret it sets the session cookie and redirects back to /admin;
+// otherwise it redirects with ?error=1 so the form can show a message.
+export async function POST(request: NextRequest) {
+  const secret = adminSecret();
+  if (!secret) {
+    return NextResponse.json(
+      { error: "ADMIN_SECRET is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const form = await request.formData();
+  const provided = String(form.get("secret") ?? "");
+
+  if (!secretMatches(provided)) {
+    // 303 forces the follow-up request to be a GET.
+    return NextResponse.redirect(new URL("/admin?error=1", request.url), 303);
+  }
+
+  const res = NextResponse.redirect(new URL("/admin", request.url), 303);
+  res.cookies.set(ADMIN_COOKIE, secret, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    // Secure flag on HTTPS only, so the cookie still works over local http.
+    secure: request.nextUrl.protocol === "https:",
+    maxAge: 60 * 60 * 24 * 7, // 1 week
+  });
+  return res;
+}

--- a/apps/web/app/api/admin/moderate/route.ts
+++ b/apps/web/app/api/admin/moderate/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "../../../../src/db";
+import { events } from "../../../../src/db/schema";
+import { isAdmin } from "../../../../src/lib/admin-auth";
+
+// Apply a human moderation decision to one event. "keep" makes it visible,
+// "reject" hides it. Records model = "manual" so it's clear a person decided.
+export async function POST(request: NextRequest) {
+  if (!(await isAdmin())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const id = typeof body?.id === "string" ? body.id : "";
+  const action = body?.action;
+
+  if (!id || (action !== "keep" && action !== "reject")) {
+    return NextResponse.json(
+      { error: "id and action ('keep' | 'reject') are required" },
+      { status: 400 },
+    );
+  }
+
+  const status = action === "keep" ? "kept" : "rejected";
+
+  const [updated] = await db
+    .update(events)
+    .set({
+      classificationStatus: status,
+      classificationModel: "manual",
+      classifiedAt: new Date(),
+    })
+    .where(eq(events.id, id))
+    .returning({ id: events.id });
+
+  if (!updated) {
+    return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true, status });
+}

--- a/apps/web/app/api/hackathons/route.ts
+++ b/apps/web/app/api/hackathons/route.ts
@@ -4,6 +4,7 @@ import { db } from "../../../src/db";
 import { events } from "../../../src/db/schema";
 import { uploadImageFromUrl } from "../../../src/lib/s3";
 import { enrichFromLuma } from "../../../src/lib/luma";
+import { classifyEvent, statusForResult } from "../../../src/lib/classifier";
 
 export async function POST(request: NextRequest) {
   const expectedSecret = process.env.HACKATHONS_API_SECRET;
@@ -54,6 +55,22 @@ export async function POST(request: NextRequest) {
   // failure just leaves the fields null. Explicit body values take precedence.
   const loc = body.link ? await enrichFromLuma(body.link) : null;
 
+  // Classify the entry as a real vs. fake/test hackathon. Best-effort: on any
+  // failure (or no OPENAI_API_KEY) the row stays "pending" and the backfill
+  // script classifies it later. High-confidence verdicts are applied here;
+  // uncertain ones become "needs_review" and are hidden until an admin acts.
+  const classification = await classifyEvent({
+    title: body.title,
+    description: body.description ?? null,
+    link: body.link ?? null,
+    city: body.city ?? loc?.city ?? null,
+    country: body.country ?? loc?.country ?? null,
+    startTime: body.startTime,
+  }).catch(() => null);
+  const classificationStatus = classification
+    ? statusForResult(classification)
+    : "pending";
+
   const [created] = await db
     .insert(events)
     .values({
@@ -75,6 +92,11 @@ export async function POST(request: NextRequest) {
       countryCode: body.countryCode ?? loc?.countryCode ?? null,
       venue: body.venue ?? loc?.venue ?? null,
       enrichedAt: loc ? new Date() : null,
+      classificationStatus,
+      classificationConfidence: classification?.confidence ?? null,
+      classificationReason: classification?.reason ?? null,
+      classificationModel: classification?.model ?? null,
+      classifiedAt: classification ? new Date() : null,
     })
     .returning();
 

--- a/apps/web/app/api/hackathons/search/route.ts
+++ b/apps/web/app/api/hackathons/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, asc, gte, ilike, isNull, or } from "drizzle-orm";
 import { db } from "../../../../src/db";
 import { events } from "../../../../src/db/schema";
+import { visibleEvents } from "../../../../src/lib/event-visibility";
 
 const DEFAULT_LIMIT = 8;
 const MAX_LIMIT = 20;
@@ -30,6 +31,7 @@ export async function GET(request: NextRequest) {
     .from(events)
     .where(
       and(
+        visibleEvents,
         or(isNull(events.endTime), gte(events.endTime, new Date())),
         or(
           ilike(events.title, `%${q}%`),

--- a/apps/web/app/hackathons/[id]/page.tsx
+++ b/apps/web/app/hackathons/[id]/page.tsx
@@ -2,9 +2,10 @@ import Image from "next/image";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "../../../src/db";
 import { events } from "../../../src/db/schema";
+import { visibleEvents } from "../../../src/lib/event-visibility";
 import { TopNav } from "../../top-nav";
 import { SiteFooter } from "../../site-footer";
 
@@ -67,7 +68,13 @@ function formatDateRange(start: Date, end: Date | null): string {
 }
 
 async function getEvent(id: string) {
-  const rows = await db.select().from(events).where(eq(events.id, id)).limit(1);
+  // Hidden (fake/test or awaiting-review) events 404 for the public, so their
+  // detail pages aren't reachable by direct link.
+  const rows = await db
+    .select()
+    .from(events)
+    .where(and(eq(events.id, id), visibleEvents))
+    .limit(1);
   return rows[0] ?? null;
 }
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 import { and, asc, gte, lte, sql } from "drizzle-orm";
 import { db } from "../src/db";
 import { events } from "../src/db/schema";
+import { visibleEvents } from "../src/lib/event-visibility";
 import { TopNav } from "./top-nav";
 import { HackathonDirectory, type DirectoryEvent } from "./hackathon-directory";
 import { SiteFooter } from "./site-footer";
@@ -21,7 +22,8 @@ function getCoverSrc(coverUrl: string | null): string | null {
 export default async function Home() {
   const now = new Date();
   const weekEnd = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
-  const upcoming = gte(events.startTime, now);
+  // Only real hackathons: the classifier hides fake/test and uncertain entries.
+  const upcoming = and(gte(events.startTime, now), visibleEvents);
 
   const [rows, totals, allTotals, cityTotals, weekTotals] = await Promise.all([
     db
@@ -44,7 +46,7 @@ export default async function Home() {
       .orderBy(asc(events.startTime))
       .limit(GRID_LIMIT),
     db.select({ count: sql<number>`count(*)::int` }).from(events).where(upcoming),
-    db.select({ count: sql<number>`count(*)::int` }).from(events),
+    db.select({ count: sql<number>`count(*)::int` }).from(events).where(visibleEvents),
     db
       .select({ count: sql<number>`count(distinct ${events.city})::int` })
       .from(events)

--- a/apps/web/app/stats/page.tsx
+++ b/apps/web/app/stats/page.tsx
@@ -1,6 +1,7 @@
-import { sql } from "drizzle-orm";
+import { and, sql } from "drizzle-orm";
 import { db } from "../../src/db";
 import { events } from "../../src/db/schema";
+import { visibleEvents } from "../../src/lib/event-visibility";
 import { TopNav } from "../top-nav";
 import { SiteFooter } from "../site-footer";
 import { sourceInfoForHost } from "../../src/lib/sources";
@@ -41,6 +42,7 @@ export default async function StatsPage() {
       upcoming: sql<number>`count(*) filter (where ${events.endTime} is null or ${events.endTime} >= now())::int`,
     })
     .from(events)
+    .where(visibleEvents)
     .groupBy(sql`substring(${events.link} from '://([^/]+)')`);
 
   // Collapse hosts into named sources (multiple hosts can map to one source).
@@ -72,7 +74,10 @@ export default async function StatsPage() {
     })
     .from(events)
     .where(
-      sql`${events.city} is not null and ${events.city} <> '' and lower(${events.city}) not in ('online', 'virtual', 'remote', 'tbd')`,
+      and(
+        visibleEvents,
+        sql`${events.city} is not null and ${events.city} <> '' and lower(${events.city}) not in ('online', 'virtual', 'remote', 'tbd')`,
+      ),
     )
     .groupBy(events.city)
     .orderBy(sql`count(*) desc, ${events.city} asc`);

--- a/apps/web/drizzle/0004_cuddly_mentallo.sql
+++ b/apps/web/drizzle/0004_cuddly_mentallo.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "events" ADD COLUMN "classification_status" text DEFAULT 'pending' NOT NULL;--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN "classification_confidence" double precision;--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN "classification_reason" text;--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN "classification_model" text;--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN "classified_at" timestamp;

--- a/apps/web/drizzle/meta/0004_snapshot.json
+++ b/apps/web/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,301 @@
+{
+  "id": "dc360b06-3e52-4f4e-ac79-a444148805bd",
+  "prevId": "8268608e-11bb-4a36-b3ec-c656788252f4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_categories": {
+      "name": "event_categories",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_categories_event_id_events_id_fk": {
+          "name": "event_categories_event_id_events_id_fk",
+          "tableFrom": "event_categories",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_categories_category_id_categories_id_fk": {
+          "name": "event_categories_category_id_categories_id_fk",
+          "tableFrom": "event_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_categories_event_id_category_id_pk": {
+          "name": "event_categories_event_id_category_id_pk",
+          "columns": [
+            "event_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cash_prize": {
+          "name": "cash_prize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participants_count": {
+          "name": "participants_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_at": {
+          "name": "enriched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_status": {
+          "name": "classification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "classification_confidence": {
+          "name": "classification_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_reason": {
+          "name": "classification_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_model": {
+          "name": "classification_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classified_at": {
+          "name": "classified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_link_unique": {
+          "name": "events_link_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "link"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1786295668772,
       "tag": "0003_kind_magus",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1786436747235,
+      "tag": "0004_cuddly_mentallo",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,8 +15,9 @@
     "db:studio": "drizzle-kit studio",
     "backfill:thumbnails": "bun scripts/backfill-thumbnails.ts",
     "backfill:locations": "bun scripts/backfill-locations.ts",
-  "backfill:devpost-descriptions": "bun scripts/backfill-devpost-descriptions.ts",
-    "prune:dead-links": "bun scripts/prune-dead-links.ts"
+    "backfill:devpost-descriptions": "bun scripts/backfill-devpost-descriptions.ts",
+    "prune:dead-links": "bun scripts/prune-dead-links.ts",
+    "classify:events": "bun scripts/classify-events.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1001.0",
@@ -31,6 +32,7 @@
     "drizzle-orm": "^0.45.1",
     "lucide-react": "^0.577.0",
     "next": "16.1.5",
+    "openai": "^7.4.0",
     "postgres": "^3.4.8",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",

--- a/apps/web/scripts/classify-events.ts
+++ b/apps/web/scripts/classify-events.ts
@@ -1,0 +1,113 @@
+// Backfill the fake/test-hackathon classifier over existing events.
+//
+// Usage:
+//   bun run classify:events                 # only unclassified ("pending") rows
+//   bun run classify:events --force         # re-classify everything
+//   bun run classify:events --limit=50      # cap for a test run
+//   bun run classify:events --dry-run       # print verdicts, write nothing
+//
+// Requires OPENAI_API_KEY. High-confidence verdicts are applied automatically
+// (kept/rejected); uncertain ones become "needs_review" for /admin. Idempotent
+// and resumable — safe to re-run.
+
+import { and, eq, isNotNull } from "drizzle-orm";
+import { db } from "../src/db";
+import { events } from "../src/db/schema";
+import {
+  classifyEvent,
+  statusForResult,
+  CLASSIFIER_MODEL,
+} from "../src/lib/classifier";
+
+const args = process.argv.slice(2);
+const FORCE = args.includes("--force");
+const DRY_RUN = args.includes("--dry-run");
+const limitArg = args.find((a) => a.startsWith("--limit="));
+const LIMIT = limitArg ? Number(limitArg.split("=")[1]) : undefined;
+
+// Keep the request rate modest so we don't trip OpenAI rate limits.
+const CONCURRENCY = 5;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function run() {
+  if (!process.env.OPENAI_API_KEY) {
+    console.error("OPENAI_API_KEY is not set — nothing to do.");
+    process.exit(1);
+  }
+
+  const conds = [isNotNull(events.title)];
+  // Only touch rows that haven't been decided yet unless --force. "pending"
+  // means never classified; "needs_review" is left for a human, not re-run.
+  if (!FORCE) conds.push(eq(events.classificationStatus, "pending"));
+
+  const rows = await db
+    .select({
+      id: events.id,
+      title: events.title,
+      description: events.description,
+      link: events.link,
+      city: events.city,
+      country: events.country,
+      startTime: events.startTime,
+    })
+    .from(events)
+    .where(and(...conds))
+    .limit(LIMIT ?? 100000);
+
+  console.log(
+    `Classifying ${rows.length} event(s) with ${CLASSIFIER_MODEL}${
+      FORCE ? " (force)" : ""
+    }${DRY_RUN ? " (dry-run)" : ""}…`,
+  );
+
+  const stats = { kept: 0, rejected: 0, needsReview: 0, failed: 0 };
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < rows.length) {
+      const idx = cursor++;
+      const row = rows[idx]!;
+      const result = await classifyEvent(row).catch(() => null);
+
+      if (!result) {
+        stats.failed++;
+      } else {
+        const status = statusForResult(result);
+        if (status === "kept") stats.kept++;
+        else if (status === "rejected") stats.rejected++;
+        else stats.needsReview++;
+
+        if (DRY_RUN) {
+          console.log(
+            `  [${status}] ${result.confidence.toFixed(2)} — ${row.title} — ${result.reason}`,
+          );
+        } else {
+          await db
+            .update(events)
+            .set({
+              classificationStatus: status,
+              classificationConfidence: result.confidence,
+              classificationReason: result.reason,
+              classificationModel: result.model,
+              classifiedAt: new Date(),
+            })
+            .where(eq(events.id, row.id));
+        }
+      }
+
+      if ((idx + 1) % 50 === 0) {
+        console.log(`  …${idx + 1}/${rows.length}`);
+        await sleep(200);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  console.log("Done:", stats);
+  process.exit(0);
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -31,6 +31,19 @@ export const events = pgTable("events", {
   countryCode: text("country_code"),
   venue: text("venue"),
   enrichedAt: timestamp("enriched_at"),
+  // LLM fake/test-hackathon classifier. status drives visibility:
+  //   pending      — not yet classified (still shown on the site)
+  //   kept         — LLM (or an admin) judged it a real hackathon
+  //   rejected     — judged fake/test; hidden from the directory
+  //   needs_review — LLM was unsure; hidden and queued for /admin review
+  // confidence is the LLM's 0–1 self-reported confidence; ≥ 0.85 is applied
+  // automatically, below that the row lands in needs_review. model records who
+  // decided (e.g. "gpt-5-nano" or "manual").
+  classificationStatus: text("classification_status").notNull().default("pending"),
+  classificationConfidence: doublePrecision("classification_confidence"),
+  classificationReason: text("classification_reason"),
+  classificationModel: text("classification_model"),
+  classifiedAt: timestamp("classified_at"),
 });
 
 export const categories = pgTable("categories", {

--- a/apps/web/src/lib/admin-auth.ts
+++ b/apps/web/src/lib/admin-auth.ts
@@ -1,0 +1,30 @@
+// Minimal shared-secret auth for the /admin moderation page.
+//
+// The secret lives only in the ADMIN_SECRET env var (set on Railway, never
+// committed) — so the code can be open source without exposing access. On a
+// correct login we drop an httpOnly cookie holding the secret and check it on
+// every admin request with a constant-time compare.
+
+import { cookies } from "next/headers";
+import { timingSafeEqual } from "node:crypto";
+
+export const ADMIN_COOKIE = "admin_session";
+
+export function adminSecret(): string | null {
+  return process.env.ADMIN_SECRET || null;
+}
+
+export function secretMatches(provided: string | undefined | null): boolean {
+  const secret = adminSecret();
+  if (!secret || !provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(secret);
+  // timingSafeEqual throws on length mismatch, so guard first.
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function isAdmin(): Promise<boolean> {
+  const store = await cookies();
+  return secretMatches(store.get(ADMIN_COOKIE)?.value);
+}

--- a/apps/web/src/lib/classifier.ts
+++ b/apps/web/src/lib/classifier.ts
@@ -1,0 +1,160 @@
+// LLM classifier that flags fake / test hackathons.
+//
+// A cheap OpenAI model reads a hackathon's title/description/link/date and
+// returns a verdict ("keep" | "remove") with a 0–1 confidence and a short
+// reason. The confidence drives what we do with it (see `statusForResult`):
+// high-confidence verdicts are applied automatically, uncertain ones are
+// queued for human review in /admin.
+//
+// This is deliberately best-effort: if OPENAI_API_KEY is unset or the call
+// fails, `classifyEvent` returns null and the caller leaves the row `pending`
+// (still visible) for the backfill script to pick up later.
+
+import OpenAI from "openai";
+
+// Cheapest capable option (see the pricing comparison that motivated this).
+// Override with CLASSIFIER_MODEL to try gpt-5-mini / gpt-4o-mini / etc.
+export const CLASSIFIER_MODEL = process.env.CLASSIFIER_MODEL ?? "gpt-5-nano";
+
+// Verdicts at or above this confidence are applied automatically; below it the
+// row is sent to /admin for a human to decide.
+export const AUTO_APPLY_THRESHOLD = 0.85;
+
+export type ClassificationVerdict = "keep" | "remove";
+
+// Mirrors events.classificationStatus in the DB schema.
+export type ClassificationStatus =
+  | "pending"
+  | "kept"
+  | "rejected"
+  | "needs_review";
+
+export interface ClassificationResult {
+  verdict: ClassificationVerdict;
+  confidence: number;
+  reason: string;
+  model: string;
+}
+
+export interface ClassifierInput {
+  title: string;
+  description?: string | null;
+  link?: string | null;
+  city?: string | null;
+  country?: string | null;
+  startTime?: Date | string | null;
+}
+
+let cachedClient: OpenAI | null = null;
+
+function getClient(): OpenAI | null {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return null;
+  cachedClient ??= new OpenAI({ apiKey });
+  return cachedClient;
+}
+
+const SYSTEM_PROMPT = `You are a strict moderator for a public directory of real hackathons.
+
+Decide whether an entry is a genuine hackathon that belongs in the directory.
+
+Return verdict "remove" for entries that are:
+- test / placeholder / demo entries ("Test Event", "asdf", "my first event", lorem ipsum, obvious QA data)
+- clearly not a hackathon (webinars, generic meetups, parties, courses, product launches, ads, spam)
+- gibberish, empty, or nonsensical titles/descriptions
+- duplicated boilerplate with no real event details
+
+Return verdict "keep" for plausible real hackathons, including small, local, student, or online ones — when in doubt about a plausible real event, prefer "keep".
+
+confidence is your certainty in the verdict, from 0 to 1. Use high confidence (>= 0.85) only when the signal is clear; use lower confidence for ambiguous cases so a human reviews them.
+reason must be one short sentence citing the specific signal you used.`;
+
+const RESPONSE_FORMAT = {
+  type: "json_schema" as const,
+  json_schema: {
+    name: "hackathon_classification",
+    strict: true,
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["verdict", "confidence", "reason"],
+      properties: {
+        verdict: { type: "string", enum: ["keep", "remove"] },
+        confidence: { type: "number" },
+        reason: { type: "string" },
+      },
+    },
+  },
+};
+
+function buildUserPrompt(input: ClassifierInput): string {
+  const start =
+    input.startTime instanceof Date
+      ? input.startTime.toISOString()
+      : (input.startTime ?? null);
+  const description = (input.description ?? "").slice(0, 2000);
+  return [
+    `Title: ${input.title}`,
+    `Link: ${input.link ?? "(none)"}`,
+    `Location: ${[input.city, input.country].filter(Boolean).join(", ") || "(unknown)"}`,
+    `Start: ${start ?? "(unknown)"}`,
+    `Description: ${description || "(none)"}`,
+  ].join("\n");
+}
+
+// Reasoning models (gpt-5*, o*) accept reasoning_effort; classic chat models
+// (gpt-4o-mini, gpt-4.1-*) reject it. Only send it when the model supports it.
+function supportsReasoningEffort(model: string): boolean {
+  return model.startsWith("gpt-5") || /^o\d/.test(model);
+}
+
+export async function classifyEvent(
+  input: ClassifierInput,
+): Promise<ClassificationResult | null> {
+  const client = getClient();
+  if (!client) return null;
+
+  const request: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming =
+    {
+      model: CLASSIFIER_MODEL,
+      response_format: RESPONSE_FORMAT,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: buildUserPrompt(input) },
+      ],
+    };
+  if (supportsReasoningEffort(CLASSIFIER_MODEL)) {
+    request.reasoning_effort = "minimal";
+  }
+
+  const completion = await client.chat.completions.create(request);
+  const content = completion.choices[0]?.message?.content;
+  if (!content) return null;
+
+  let parsed: { verdict?: unknown; confidence?: unknown; reason?: unknown };
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  const verdict = parsed.verdict === "remove" ? "remove" : "keep";
+  const rawConfidence = Number(parsed.confidence);
+  const confidence = Number.isFinite(rawConfidence)
+    ? Math.min(1, Math.max(0, rawConfidence))
+    : 0;
+  const reason = typeof parsed.reason === "string" ? parsed.reason : "";
+
+  return { verdict, confidence, reason, model: CLASSIFIER_MODEL };
+}
+
+// Maps a classifier result to the stored status. High-confidence verdicts are
+// applied; anything less certain is queued for human review.
+export function statusForResult(
+  result: ClassificationResult,
+): ClassificationStatus {
+  if (result.confidence >= AUTO_APPLY_THRESHOLD) {
+    return result.verdict === "keep" ? "kept" : "rejected";
+  }
+  return "needs_review";
+}

--- a/apps/web/src/lib/event-visibility.ts
+++ b/apps/web/src/lib/event-visibility.ts
@@ -1,0 +1,16 @@
+// Single source of truth for which events are publicly visible.
+//
+// The LLM classifier (see lib/classifier.ts) can hide an event by setting its
+// classification_status to "rejected" (judged fake/test) or "needs_review"
+// (uncertain — awaiting a human in /admin). Everything else ("pending" and
+// "kept") is shown. Apply `visibleEvents` to every public read query.
+
+import { notInArray } from "drizzle-orm";
+import { events } from "../db/schema";
+
+// Statuses hidden from the public directory.
+export const HIDDEN_STATUSES = ["rejected", "needs_review"] as const;
+
+export const visibleEvents = notInArray(events.classificationStatus, [
+  ...HIDDEN_STATUSES,
+]);

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "drizzle-orm": "^0.45.1",
         "lucide-react": "^0.577.0",
         "next": "16.1.5",
+        "openai": "^7.4.0",
         "postgres": "^3.4.8",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
@@ -1384,6 +1385,8 @@
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "openai": ["openai@7.4.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-+C9Muit5x8j9R8ej8ZzVgKcrVDtqFqTy9gxFdov0EItLgU68zrJtF9ZeT0cyqJQW9S3PCJkdFgADtRGquRBtew=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
-  "globalEnv": ["HACKATHONS_API_SECRET"],
+  "globalEnv": [
+    "HACKATHONS_API_SECRET",
+    "OPENAI_API_KEY",
+    "CLASSIFIER_MODEL",
+    "ADMIN_SECRET"
+  ],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
Cheap OpenAI classifier (gpt-5-nano) that flags fake/test hackathons with a confidence score.

- **DB**: `events` gains `classification_status` (pending/kept/rejected/needs_review) + confidence/reason/model/classified_at (migration 0004, already applied to prod).
- **Classifier** (`src/lib/classifier.ts`): structured-output verdict; confidence ≥ 0.85 auto-applied, else `needs_review`.
- **Ingest**: `POST /api/hackathons` classifies each new event (best-effort).
- **Public reads** (home, detail, search, stats) hide `rejected`/`needs_review`.
- **Backfill**: `bun run classify:events`.
- **/admin**: secret-gated moderation queue (keep/reject) via `ADMIN_SECRET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)