### PR TITLE
fix(web): asymmetric classifier thresholds

### DIFF
--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -36,9 +36,10 @@ export const events = pgTable("events", {
   //   kept         — LLM (or an admin) judged it a real hackathon
   //   rejected     — judged fake/test; hidden from the directory
   //   needs_review — LLM was unsure; hidden and queued for /admin review
-  // confidence is the LLM's 0–1 self-reported confidence; ≥ 0.85 is applied
-  // automatically, below that the row lands in needs_review. model records who
-  // decided (e.g. "gpt-5-nano" or "manual").
+  // confidence is the LLM's 0–1 self-reported confidence. Thresholds are
+  // asymmetric (see lib/classifier.ts): a "keep" is applied at low confidence
+  // (safe default), a "remove" only at high confidence; the rest land in
+  // needs_review. model records who decided (e.g. "gpt-5-nano" or "manual").
   classificationStatus: text("classification_status").notNull().default("pending"),
   classificationConfidence: doublePrecision("classification_confidence"),
   classificationReason: text("classification_reason"),

--- a/apps/web/src/lib/classifier.ts
+++ b/apps/web/src/lib/classifier.ts
@@ -16,9 +16,14 @@ import OpenAI from "openai";
 // Override with CLASSIFIER_MODEL to try gpt-5-mini / gpt-4o-mini / etc.
 export const CLASSIFIER_MODEL = process.env.CLASSIFIER_MODEL ?? "gpt-5-nano";
 
-// Verdicts at or above this confidence are applied automatically; below it the
-// row is sent to /admin for a human to decide.
-export const AUTO_APPLY_THRESHOLD = 0.85;
+// Thresholds are asymmetric by design. "keep" is the safe default — the event
+// stays visible, same as before any classifier existed — so we auto-apply it at
+// a low bar (cheap models are systematically under-confident on genuine events).
+// "remove" HIDES an event, which is the harmful direction if wrong, so we only
+// auto-apply it when the model is highly confident. Everything in between is
+// sent to /admin for a human to decide.
+export const AUTO_KEEP_THRESHOLD = 0.6;
+export const AUTO_REJECT_THRESHOLD = 0.85;
 
 export type ClassificationVerdict = "keep" | "remove";
 
@@ -153,8 +158,10 @@ export async function classifyEvent(
 export function statusForResult(
   result: ClassificationResult,
 ): ClassificationStatus {
-  if (result.confidence >= AUTO_APPLY_THRESHOLD) {
-    return result.verdict === "keep" ? "kept" : "rejected";
+  if (result.verdict === "keep") {
+    // Safe direction: keep visible unless the model is very unsure.
+    return result.confidence >= AUTO_KEEP_THRESHOLD ? "kept" : "needs_review";
   }
-  return "needs_review";
+  // Harmful direction: only hide automatically when highly confident.
+  return result.confidence >= AUTO_REJECT_THRESHOLD ? "rejected" : "needs_review";
 }


### PR DESCRIPTION
Follow-up to #37. gpt-5-nano under-rates genuine hackathons (0.60–0.78 in testing), so a flat 0.85 threshold would hide the whole directory. Now: keep applies at ≥0.6 (safe default, stays visible), remove only at ≥0.85 (hiding is the harmful direction), rest → /admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)