### PR TITLE
fix(web): keep verdicts never auto-hide

### DIFF
--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -36,10 +36,10 @@ export const events = pgTable("events", {
   //   kept         — LLM (or an admin) judged it a real hackathon
   //   rejected     — judged fake/test; hidden from the directory
   //   needs_review — LLM was unsure; hidden and queued for /admin review
-  // confidence is the LLM's 0–1 self-reported confidence. Thresholds are
-  // asymmetric (see lib/classifier.ts): a "keep" is applied at low confidence
-  // (safe default), a "remove" only at high confidence; the rest land in
-  // needs_review. model records who decided (e.g. "gpt-5-nano" or "manual").
+  // confidence is the LLM's 0–1 self-reported confidence. Policy (see
+  // lib/classifier.ts): a "keep" always stays visible; a "remove" hides the
+  // event only at high confidence, otherwise it lands in needs_review. model
+  // records who decided (e.g. "gpt-5-nano" or "manual").
   classificationStatus: text("classification_status").notNull().default("pending"),
   classificationConfidence: doublePrecision("classification_confidence"),
   classificationReason: text("classification_reason"),

--- a/apps/web/src/lib/classifier.ts
+++ b/apps/web/src/lib/classifier.ts
@@ -16,13 +16,13 @@ import OpenAI from "openai";
 // Override with CLASSIFIER_MODEL to try gpt-5-mini / gpt-4o-mini / etc.
 export const CLASSIFIER_MODEL = process.env.CLASSIFIER_MODEL ?? "gpt-5-nano";
 
-// Thresholds are asymmetric by design. "keep" is the safe default — the event
-// stays visible, same as before any classifier existed — so we auto-apply it at
-// a low bar (cheap models are systematically under-confident on genuine events).
-// "remove" HIDES an event, which is the harmful direction if wrong, so we only
-// auto-apply it when the model is highly confident. Everything in between is
-// sent to /admin for a human to decide.
-export const AUTO_KEEP_THRESHOLD = 0.6;
+// A "keep" verdict never hides an event: keeping is the safe default (the same
+// as before any classifier existed), so we don't second-guess the model when it
+// judges an event real — cheap models are systematically under-confident on
+// genuine events, and hiding a real hackathon is the worst outcome for a
+// directory. Only "remove" hides an event: automatically when the model is
+// highly confident, otherwise it goes to /admin for a human. This keeps the
+// directory full and the review queue small and meaningful.
 export const AUTO_REJECT_THRESHOLD = 0.85;
 
 export type ClassificationVerdict = "keep" | "remove";
@@ -158,10 +158,8 @@ export async function classifyEvent(
 export function statusForResult(
   result: ClassificationResult,
 ): ClassificationStatus {
-  if (result.verdict === "keep") {
-    // Safe direction: keep visible unless the model is very unsure.
-    return result.confidence >= AUTO_KEEP_THRESHOLD ? "kept" : "needs_review";
-  }
-  // Harmful direction: only hide automatically when highly confident.
+  // A "keep" never auto-hides — keeping is the safe default.
+  if (result.verdict === "keep") return "kept";
+  // "remove" hides the event: automatically only when highly confident.
   return result.confidence >= AUTO_REJECT_THRESHOLD ? "rejected" : "needs_review";
 }


### PR DESCRIPTION
Follow-up to #38. Backfill showed ~22% of events hidden as needs_review, mostly low-confidence keeps (real events). Now a keep always stays visible; only remove hides (auto ≥0.85, else review). Keeps the directory full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)